### PR TITLE
Optimizing mul method of point class with BcMath

### DIFF
--- a/classes/Point.php
+++ b/classes/Point.php
@@ -220,13 +220,9 @@ class Point implements PointInterface {
 
                         $result = self::double($result);
 
-                        if (gmp_cmp(gmp_and($e3, $i), 0) != 0 && gmp_cmp(gmp_and($e, $i), 0) == 0) {
-
-                            $result = self::add($result, $p1);
-                        }
-                        if (gmp_cmp(gmp_and($e3, $i), 0) == 0 && gmp_cmp(gmp_and($e, $i), 0) != 0) {
-                            $result = self::add($result, $negative_self);
-                        }
+                        $e3bit = bccomp(bcmath_Utils::bcand($e3, $i), 0);
+                        $ebit = bccomp(bcmath_Utils::bcand($e, $i), 0);
+                        if ($e3bit != $ebit) $result = self::add($result, (($e3bit == 0)? $negative_self : $p1));
 
                         $i = gmp_strval(gmp_div($i, 2));
                     }


### PR DESCRIPTION
I'm very interested in using ECDH on a website, but the server where it will be hosted does not have GMP, only BCMath. I really liked your code and I'm trying to optimize it when using the bcmath. The replacement I made in the Mul method of the Point class managed save about 33% in some operations, how to generate public key or secret key. The original code was repeating the execution of bcmath_Utils::bcand.
