### PR TITLE
Composer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This package is released under the MIT license.
 
 You can install this library via Composer :
 
-`composer require mdanter/ecc:~0.1`
+=======
+`composer require mdanter/ecc`
 
 ### Contribute
 


### PR DESCRIPTION
It's no longer necessary to include the version in composer install commands, as it selects the latest stable release by default.

This avoids having to maintain the install instruction in sync with the latest release number.
