### PR TITLE
gmp_strval = bad

### DIFF
--- a/benchmark.php
+++ b/benchmark.php
@@ -9,6 +9,7 @@ $t = microtime(true);
 
 $g = EccFactory::getSecgCurves($math = EccFactory::getAdapter())->generator256k1();
 $privKey = "105366245268346348601399826821003822098691517983742654654633135381666943167285";
+$privKey = gmp_init($privKey, 10);
 
 for ($i = 0; $i < 160; $i++) {
     $g->mul($privKey);

--- a/benchmark.php
+++ b/benchmark.php
@@ -1,0 +1,17 @@
+<?php
+
+use Mdanter\Ecc\EccFactory;
+
+require_once(__DIR__. '/vendor/autoload.php');
+
+
+$t = microtime(true);
+
+$g = EccFactory::getSecgCurves($math = EccFactory::getAdapter())->generator256k1();
+$privKey = "105366245268346348601399826821003822098691517983742654654633135381666943167285";
+
+for ($i = 0; $i < 160; $i++) {
+    $g->mul($privKey);
+}
+
+var_dump(microtime(true) - $t);

--- a/src/Math/Gmp.php
+++ b/src/Math/Gmp.php
@@ -12,7 +12,7 @@ class Gmp implements MathAdapterInterface
      */
     public function cmp($first, $other)
     {
-        return gmp_cmp(gmp_init($first, 10), gmp_init($other, 10));
+        return gmp_cmp($first, $other);
     }
 
     /**
@@ -21,7 +21,7 @@ class Gmp implements MathAdapterInterface
      */
     public function mod($number, $modulus)
     {
-        return gmp_strval(gmp_mod(gmp_init($number, 10), gmp_init($modulus, 10)));
+        return gmp_mod($number, $modulus);
     }
 
     /**
@@ -30,7 +30,7 @@ class Gmp implements MathAdapterInterface
      */
     public function add($augend, $addend)
     {
-        return gmp_strval(gmp_add(gmp_init($augend, 10), gmp_init($addend, 10)));
+        return gmp_add($augend, $addend);
     }
 
     /**
@@ -39,7 +39,7 @@ class Gmp implements MathAdapterInterface
      */
     public function sub($minuend, $subtrahend)
     {
-        return gmp_strval(gmp_sub(gmp_init($minuend, 10), gmp_init($subtrahend, 10)));
+        return gmp_sub($minuend, $subtrahend);
     }
 
     /**
@@ -48,7 +48,7 @@ class Gmp implements MathAdapterInterface
      */
     public function mul($multiplier, $multiplicand)
     {
-        return gmp_strval(gmp_mul(gmp_init($multiplier, 10), gmp_init($multiplicand, 10)));
+        return gmp_mul($multiplier, $multiplicand);
     }
 
     /**
@@ -57,7 +57,7 @@ class Gmp implements MathAdapterInterface
      */
     public function div($dividend, $divisor)
     {
-        return gmp_strval(gmp_div(gmp_init($dividend, 10), gmp_init($divisor, 10)));
+        return gmp_div($dividend, $divisor);
     }
 
     /**
@@ -66,7 +66,7 @@ class Gmp implements MathAdapterInterface
      */
     public function pow($base, $exponent)
     {
-        return gmp_strval(gmp_pow(gmp_init($base, 10), $exponent));
+        return gmp_pow($base, $exponent);
     }
 
     /**
@@ -75,7 +75,7 @@ class Gmp implements MathAdapterInterface
      */
     public function bitwiseAnd($first, $other)
     {
-        return gmp_strval(gmp_and(gmp_init($first, 10), gmp_init($other, 10)));
+        return gmp_and($first, $other);
     }
 
     /**
@@ -85,7 +85,7 @@ class Gmp implements MathAdapterInterface
     public function rightShift($number, $positions)
     {
         // Shift 1 right = div / 2
-        return gmp_strval(gmp_div($number, gmp_pow(2, $positions)));
+        return gmp_div($number, gmp_pow(2, $positions));
     }
 
     /**
@@ -94,7 +94,7 @@ class Gmp implements MathAdapterInterface
      */
     public function bitwiseXor($first, $other)
     {
-        return gmp_strval(gmp_xor(gmp_init($first, 10), gmp_init($other, 10)));
+        return gmp_xor($first, $other);
     }
 
     /**
@@ -104,7 +104,7 @@ class Gmp implements MathAdapterInterface
     public function leftShift($number, $positions)
     {
         // Shift 1 left = mul by 2
-        return gmp_strval(gmp_mul(gmp_init($number), gmp_pow(2, $positions)));
+        return gmp_mul(gmp_init($number), gmp_pow(2, $positions));
     }
 
     /**
@@ -114,7 +114,7 @@ class Gmp implements MathAdapterInterface
     public function toString($value)
     {
         if (is_resource($value)) {
-            return gmp_strval($value);
+            return $value;
         }
 
         return $value;
@@ -154,7 +154,7 @@ class Gmp implements MathAdapterInterface
             throw new \InvalidArgumentException("Negative exponents ($exponent) not allowed.");
         }
 
-        return gmp_strval(gmp_powm(gmp_init($base, 10), gmp_init($exponent, 10), gmp_init($modulus, 10)));
+        return gmp_powm($base, $exponent, $modulus);
     }
 
     /**
@@ -163,7 +163,7 @@ class Gmp implements MathAdapterInterface
      */
     public function isPrime($n)
     {
-        $prob = gmp_prob_prime(gmp_init($n, 10));
+        $prob = gmp_prob_prime($n);
 
         if ($prob > 0) {
             return true;
@@ -178,7 +178,7 @@ class Gmp implements MathAdapterInterface
      */
     public function nextPrime($starting_value)
     {
-        return gmp_strval(gmp_nextprime(gmp_init($starting_value, 10)));
+        return gmp_nextprime($starting_value);
     }
 
     /**
@@ -187,7 +187,7 @@ class Gmp implements MathAdapterInterface
      */
     public function inverseMod($a, $m)
     {
-        return gmp_strval(gmp_invert(gmp_init($a, 10), gmp_init($m, 10)));
+        return gmp_invert($a, $m);
     }
 
     /**
@@ -196,7 +196,7 @@ class Gmp implements MathAdapterInterface
      */
     public function jacobi($a, $n)
     {
-        return gmp_strval(gmp_jacobi(gmp_init($a, 10), gmp_init($n, 10)));
+        return gmp_jacobi($a, $n);
     }
 
     /**
@@ -205,7 +205,7 @@ class Gmp implements MathAdapterInterface
      */
     public function intToString($x)
     {
-        $x = gmp_init($x, 10);
+        $x = $x;
 
         if (gmp_cmp($x, 0) == 0) {
             return chr(0);
@@ -218,7 +218,7 @@ class Gmp implements MathAdapterInterface
                 $q = gmp_div($x, 256, 0);
                 $r = gmp_mod($x, 256);
 
-                $ascii = chr(gmp_strval($r));
+                $ascii = chr($r);
 
                 $result = $ascii . $result;
                 $x = $q;
@@ -266,11 +266,12 @@ class Gmp implements MathAdapterInterface
             $b = $temp;
         }
 
-        return gmp_strval($b);
+        return $b;
     }
 
     public function baseConvert($number, $from, $to)
     {
-        return gmp_strval(gmp_init($number, $from), $to);
+        $number = $number instanceof \GMP ? $number : gmp_init($number, $from);
+        return gmp_strval($number, $to);
     }
 }

--- a/src/Point.php
+++ b/src/Point.php
@@ -92,7 +92,7 @@ class Point implements PointInterface
 
     public function isInfinity()
     {
-        return (bool) $this->infinity;
+        return (bool) gmp_strval($this->infinity, 10);
     }
 
     /**
@@ -270,7 +270,8 @@ class Point implements PointInterface
 
         $mask = 1 - intval($cond);
         $mask = str_pad('', $size, $mask, STR_PAD_LEFT);
-        $mask = $this->adapter->baseConvert($mask, 2, 10);
+        $mask = gmp_init($mask, 2);
+        // $mask = $this->adapter->baseConvert($mask, 2, 10);
 
         $tA = $this->adapter->bitwiseAnd($a, $mask);
         $tB = $this->adapter->bitwiseAnd($b, $mask);
@@ -282,7 +283,7 @@ class Point implements PointInterface
 
     private function validate()
     {
-        if (! $this->infinity && ! $this->curve->contains($this->x, $this->y)) {
+        if (! gmp_strval($this->infinity, 10) && ! $this->curve->contains($this->x, $this->y)) {
             throw new \RuntimeException('Invalid point');
         }
     }


### PR DESCRIPTION
just doing this PR to start a discussion ;-)

Now that bcmath has been dropped as dependancy I think it doesn't make much sence anymore to keep converting between strings and gmp resources using `gmp_init` and `gmp_strval` all the time.

The converting has about a 50% performance impact (see benchmark below and code in this PR), which is a pretty hefty price imo for abstraction.

I also tried doing `$val instanceof \GMP || is_resource($val) ? $val : gmp_init($val, 10);` but that also put a fair strain on the performance. 

without changes:
```
$ php benchmark.php 
double(35.028147935867)
```

with changes:
```
$ php benchmark.php 
double(18.148168802261)
```

I think most tests are failing btw because they `$this->assertEquals("str", \GMP)` now, so some simple `gmp_strval` in there and they seem to pass ( I tried a few )