### PR TITLE
EcDomain + parameters serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=5.4.0",
         "ext-gmp": "*",
         "ext-mcrypt": "*",
-        "fgrosse/phpasn1": "~1.3.1",
+        "fgrosse/phpasn1": "~1.4",
         "symfony/console": "~2.6"
     },
     "require-dev": {

--- a/src/Curves/CurveFactory.php
+++ b/src/Curves/CurveFactory.php
@@ -26,6 +26,8 @@ class CurveFactory
                 return $nistFactory->curve384();
             case NistCurve::NAME_P521:
                 return $nistFactory->curve521();
+            case SecgCurve::NAME_SECP_112R1:
+                return $secpFactory->curve112r1();
             case SecgCurve::NAME_SECP_256K1:
                 return $secpFactory->curve256k1();
             case SecgCurve::NAME_SECP_256R1:
@@ -57,6 +59,8 @@ class CurveFactory
                 return $nistFactory->generator384();
             case NistCurve::NAME_P521:
                 return $nistFactory->generator521();
+            case SecgCurve::NAME_SECP_112R1:
+                return $secpFactory->generator112r1();
             case SecgCurve::NAME_SECP_256K1:
                 return $secpFactory->generator256k1();
             case SecgCurve::NAME_SECP_256R1:

--- a/src/Curves/CurveRandomSeed.php
+++ b/src/Curves/CurveRandomSeed.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Mdanter\Ecc\Curves;
+
+
+class CurveRandomSeed
+{
+
+    /**
+     * @var array
+     */
+    private static $seedMap = [
+        NistCurve::NAME_P192 => '3045AE6FC8422F64ED579528D38120EAE12196D5',
+        NistCurve::NAME_P224 => 'BD71344799D5C7FCDC45B59FA3B9AB8F6A948BC5',
+        NistCurve::NAME_P256 => 'C49D360886E704936A6678E1139D26B7819F7E90',
+        NistCurve::NAME_P384 => 'A335926AA319A27A1D00896A6773A4827ACDAC73',
+        NistCurve::NAME_P521 => 'D09E8800291CB85396CC6717393284AAA0DA64BA',
+        SecgCurve::NAME_SECP_112R1 => '00F50B028E4D696E676875615175290472783FB1',
+        SecgCurve::NAME_SECP_256R1 => 'C49D360886E704936A6678E1139D26B7819F7E90',
+        SecgCurve::NAME_SECP_384R1 => 'A335926AA319A27A1D00896A6773A4827ACDAC73'
+    ];
+
+    /**
+     * @param NamedCurveFp $curve
+     */
+    public static function getSeed(NamedCurveFp $curve)
+    {
+        $keys = array_keys(self::$seedMap);
+
+        if (in_array($curve->getName(), $keys)) {
+            $name = $curve->getName();
+            $map = self::$seedMap;
+            if (!isset($map[$name])) {
+                throw new \RuntimeException('Curve not known to seed map');
+            }
+
+            return $map[$name];
+        }
+
+        throw new \InvalidArgumentException('Curve must be from NIST set');
+    }
+}

--- a/src/Curves/NamedCurveFp.php
+++ b/src/Curves/NamedCurveFp.php
@@ -16,7 +16,7 @@ class NamedCurveFp extends CurveFp
      * @param int|string           $name
      * @param int|string           $prime
      * @param int|string           $a
-     * @param MathAdapterInterface $b
+     * @param int|string           $b
      * @param MathAdapterInterface $adapter
      */
     public function __construct($name, $prime, $a, $b, MathAdapterInterface $adapter)

--- a/src/Curves/NistCurve.php
+++ b/src/Curves/NistCurve.php
@@ -39,6 +39,8 @@ use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
 class NistCurve
 {
 
+    const SET_NAME = 'NistCurve';
+
     const NAME_P192 = 'nist-p192';
 
     const NAME_P224 = 'nist-p224';

--- a/src/Curves/SecgCurve.php
+++ b/src/Curves/SecgCurve.php
@@ -36,6 +36,8 @@ class SecgCurve
 {
     private $adapter;
 
+    const SET_NAME = 'SecgCurve';
+
     const NAME_SECP_112R1 = 'secp112r1';
 
     const NAME_SECP_256K1 = 'secp256k1';

--- a/src/EccFactory.php
+++ b/src/EccFactory.php
@@ -3,11 +3,14 @@
 namespace Mdanter\Ecc;
 
 use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Curves\CurveFactory;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Curves\SecgCurve;
 use Mdanter\Ecc\Math\MathAdapterFactory;
 use Mdanter\Ecc\Math\MathAdapterInterface;
 use Mdanter\Ecc\Primitives\CurveFp;
+use Mdanter\Ecc\Primitives\EcDomain;
+use Mdanter\Ecc\Util\Hasher;
 
 /**
  * Static factory class providing factory methods to work with NIST and SECG recommended curves.
@@ -77,13 +80,29 @@ class EccFactory
     }
 
     /**
-     *
      * @param  MathAdapterInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapteR()
      * @return \Mdanter\Ecc\Crypto\Signature\Signer;
-
      */
     public static function getSigner(MathAdapterInterface $adapter = null)
     {
         return new Signer($adapter ?: self::getAdapter());
+    }
+
+    /**
+     * @param $curveName
+     * @param $hashAlgorithm
+     * @param MathAdapterInterface|null $adapter
+     * @return EcDomain
+     */
+    public static function getDomain($curveName, $hashAlgorithm, MathAdapterInterface $adapter = null)
+    {
+        $adapter = $adapter ?: self::getAdapter();
+
+        return new EcDomain(
+            $adapter,
+            CurveFactory::getCurveByName($curveName),
+            CurveFactory::getGeneratorByName($curveName),
+            new Hasher($adapter, $hashAlgorithm)
+        );
     }
 }

--- a/src/EccFactory.php
+++ b/src/EccFactory.php
@@ -89,8 +89,8 @@ class EccFactory
     }
 
     /**
-     * @param $curveName
-     * @param $hashAlgorithm
+     * @param string $curveName
+     * @param string $hashAlgorithm
      * @param MathAdapterInterface|null $adapter
      * @return EcDomain
      */

--- a/src/Primitives/EcDomain.php
+++ b/src/Primitives/EcDomain.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+
+use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Curves\NamedCurveFp;
+use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Util\Hasher;
+
+class EcDomain
+{
+    /**
+     * @var NamedCurveFp
+     */
+    private $curve;
+
+    /**
+     * @var GeneratorPoint
+     */
+    private $generator;
+
+    /**
+     * @var Hasher
+     */
+    private $hasher;
+
+    /**
+     * @var MathAdapterInterface
+     */
+    private $math;
+
+    /**
+     * @param MathAdapterInterface $math
+     * @param NamedCurveFp $curve
+     * @param GeneratorPoint $generatorPoint
+     * @param Hasher $hasher - must be a known hash algorithm
+     */
+    public function __construct(MathAdapterInterface $math, NamedCurveFp $curve, GeneratorPoint $generatorPoint, Hasher $hasher)
+    {
+        if (!$curve->contains($generatorPoint->getX(), $generatorPoint->getY())) {
+            throw new \RuntimeException('Provided generator point does not exist on curve');
+        }
+
+        $this->hasher = $hasher;
+        $this->curve = $curve;
+        $this->generator = $generatorPoint;
+        $this->math = $math;
+    }
+
+    /**
+     * @return NamedCurveFp
+     */
+    public function getCurve()
+    {
+        return $this->curve;
+    }
+
+    /**
+     * @return GeneratorPoint
+     */
+    public function getGenerator()
+    {
+        return $this->generator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSigAlgorithm()
+    {
+        return "ecdsa+" . $this->getHasher()->getAlgo();
+    }
+
+    /**
+     * @return Hasher
+     */
+    public function getHasher()
+    {
+        return $this->hasher;
+    }
+
+    /**
+     * @return Signer
+     */
+    public function getSigner()
+    {
+        return new Signer($this->math);
+    }
+}

--- a/src/Primitives/Point.php
+++ b/src/Primitives/Point.php
@@ -259,6 +259,7 @@ class Point implements PointInterface
             return $this->curve->getInfinity();
         }
 
+        /** @var Point[] $r */
         $r = [
             $this->curve->getInfinity(),
             clone $this

--- a/src/Serializer/Curves/EcParamsOidSerializer.php
+++ b/src/Serializer/Curves/EcParamsOidSerializer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Curves;
+
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+use Mdanter\Ecc\Curves\NamedCurveFp;
+use FG\ASN1\Universal\ObjectIdentifier;
+
+class EcParamsOidSerializer
+{
+    const HEADER = '-----BEGIN EC PARAMETERS-----';
+    const FOOTER = '-----END EC PARAMETERS-----';
+
+    /**
+     * @param NamedCurveFp $c
+     * @return string
+     */
+    public function serialize(NamedCurveFp $c)
+    {
+        $oid = CurveOidMapper::getCurveOid($c);
+
+        $content = self::HEADER . PHP_EOL .
+            base64_encode($oid->getBinary()) . PHP_EOL .
+            self::FOOTER;
+
+        return $content;
+    }
+
+    /**
+     * @param string $params
+     * @return \Mdanter\Ecc\Curves\NamedCurveFp
+     */
+    public function parse($params)
+    {
+        $params = str_replace(self::HEADER, '', $params);
+        $params = str_replace(self::FOOTER, '', $params);
+
+        $oid = ObjectIdentifier::fromBinary(base64_decode($params));
+        return CurveOidMapper::getCurveFromOid($oid);
+    }
+}

--- a/src/Serializer/Curves/EcParamsSerializer.php
+++ b/src/Serializer/Curves/EcParamsSerializer.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Curves;
+
+
+use FG\ASN1\Universal\BitString;
+use FG\ASN1\Universal\Integer;
+use FG\ASN1\Universal\ObjectIdentifier;
+use FG\ASN1\Universal\OctetString;
+use FG\ASN1\Universal\Sequence;
+use Mdanter\Ecc\Curves\NamedCurveFp;
+use Mdanter\Ecc\Curves\CurveRandomSeed;
+use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+//use Mdanter\Ecc\Serializer\Util\HashAlgorithmOidMapper;
+
+/**
+ * Serialize a named curve to it's explicit parameters.
+ */
+class EcParamsSerializer
+{
+    const VERSION = 3;
+    const HEADER = '-----BEGIN EC PARAMETERS-----';
+    const FOOTER = '-----END EC PARAMETERS-----';
+
+    const FIELD_ID = '1.2.840.10045.1.1';
+
+    /**
+     * @param UncompressedPointSerializer $pointSerializer
+     */
+    public function __construct(UncompressedPointSerializer $pointSerializer)
+    {
+        $this->pointSerializer = $pointSerializer;
+    }
+
+    /**
+     * @param NamedCurveFp $c
+     * @return Sequence
+     */
+    private function getFieldIdAsn(MathAdapterInterface $math, NamedCurveFp $c)
+    {
+        return new Sequence(
+            new ObjectIdentifier(self::FIELD_ID), // 1.2.840.10045.3.1.1.7
+            new Integer($c->getPrime())
+        );
+    }
+
+    /**
+     * @param MathAdapterInterface $math
+     * @param NamedCurveFp $c
+     * @return Sequence
+     */
+    private function getCurveAsn(MathAdapterInterface $math, NamedCurveFp $c)
+    {
+        $a = new OctetString($math->decHex($math->mod($c->getA(), $c->getPrime())));
+        $b = new OctetString($math->decHex($math->mod($c->getB(), $c->getPrime())));
+
+        try {
+            $seed = CurveRandomSeed::getSeed($c);
+            return new Sequence(
+                $a,
+                $b,
+                new BitString($seed)
+            );
+        } catch (\Exception $e) {
+            return new Sequence(
+                $a,
+                $b
+            );
+        }
+    }
+
+    /**
+     * @param NamedCurveFp $c
+     * @param GeneratorPoint $G
+     * @return string
+     */
+    public function serialize(NamedCurveFp $c, GeneratorPoint $G)
+    {
+        $math = $G->getAdapter();
+
+        $fieldID = $this->getFieldIdAsn($math, $c);
+        $curve = $this->getCurveAsn($math, $c);
+
+        $domain = new Sequence(
+            new Integer(1),
+            $fieldID,
+            $curve,
+            new OctetString($this->pointSerializer->serialize($G)),
+            new Integer($G->getOrder()),
+            new Integer(1)
+            // Hash function oid ?
+        );
+
+        $payload = $domain->getBinary();
+
+        $content = self::HEADER . PHP_EOL
+            . trim(chunk_split(base64_encode($payload), 64, PHP_EOL)).PHP_EOL
+            . self::FOOTER;
+
+        return $content;
+    }
+
+    /**
+     * @param string $params
+     * @return \Mdanter\Ecc\Curves\NamedCurveFp
+     */
+    public function parse($params)
+    {
+        $params = str_replace(self::HEADER, '', $params);
+        $params = str_replace(self::FOOTER, '', $params);
+
+        $oid = ObjectIdentifier::fromBinary(base64_decode($params));
+        return CurveOidMapper::getCurveFromOid($oid);
+    }
+}

--- a/src/Serializer/Util/CurveOidMapper.php
+++ b/src/Serializer/Util/CurveOidMapper.php
@@ -22,6 +22,8 @@ class CurveOidMapper
 
     const NIST_P521_OID = '1.3.132.0.35';
 
+    const SECP_112R1_OID = '1.3.132.0.6';
+
     const SECP_256K1_OID = '1.3.132.0.10';
 
     const SECP_256R1_OID = '1.2.840.10045.3.1.7';
@@ -37,7 +39,9 @@ class CurveOidMapper
         NistCurve::NAME_P256 => self::NIST_P256_OID,
         NistCurve::NAME_P384 => self::NIST_P384_OID,
         NistCurve::NAME_P521 => self::NIST_P521_OID,
+        SecgCurve::NAME_SECP_112R1 => self::SECP_112R1_OID,
         SecgCurve::NAME_SECP_256K1 => self::SECP_256K1_OID,
+        SecgCurve::NAME_SECP_256R1 => self::SECP_256R1_OID,
         SecgCurve::NAME_SECP_384R1 => self::SECP_384R1_OID,
     );
 
@@ -45,12 +49,14 @@ class CurveOidMapper
      * @var array
      */
     private static $sizeMap = array(
-        NistCurve::NAME_P192 => 12,
+        NistCurve::NAME_P192 => 24,
         NistCurve::NAME_P224 => 28,
         NistCurve::NAME_P256 => 32,
         NistCurve::NAME_P384 => 48,
         NistCurve::NAME_P521 => 66,
+        SecgCurve::NAME_SECP_112R1 => 14,
         SecgCurve::NAME_SECP_256K1 => 28,
+        SecgCurve::NAME_SECP_256R1 => 28,
         SecgCurve::NAME_SECP_384R1 => 48,
     );
 

--- a/src/Serializer/Util/HashAlgorithmOidMapper.php
+++ b/src/Serializer/Util/HashAlgorithmOidMapper.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Util;
+
+
+use FG\ASN1\Universal\ObjectIdentifier;
+use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Util\Hasher;
+
+class HashAlgorithmOidMapper
+{
+
+    const SHA1_OID = '1.3.14.3.2.26.1';
+    const SHA224_OID = '2.16.840.1.101.3.4.2.4';
+    const SHA256_OID = '2.16.840.1.101.3.4.2.1';
+    const SHA384_OID = '2.16.840.1.101.3.4.2.2';
+    const SHA512_OID = '2.16.840.1.101.3.4.2.3';
+
+    /**
+     * @var array
+     */
+    private static $oidMap = array(
+        'sha1' => self::SHA1_OID,
+        'sha224' => self::SHA224_OID,
+        'sha256' => self::SHA256_OID,
+        'sha384' => self::SHA384_OID,
+        'sha512' => self::SHA512_OID
+    );
+
+    /**
+     * @var array
+     */
+    private static $sizeMap = array(
+        'sha1' => 40,
+        'sha224' => 56,
+        'sha256' => 64,
+        'sha384' => 96,
+        'sha512' => 128
+    );
+
+    /**
+     * @return array
+     */
+    public static function getNames()
+    {
+        return array_keys(self::$oidMap);
+    }
+
+    /**
+     * @param string $hashAlgo
+     * @return integer
+     * @throws \RuntimeException
+     */
+    public static function getByteSize($hashAlgo)
+    {
+        if (array_key_exists($hashAlgo, self::$sizeMap)) {
+            return self::$sizeMap[$hashAlgo];
+        }
+
+        throw new \InvalidArgumentException('Unsupported hashing algorithm.');
+    }
+
+    /**
+     * @param string $hashAlgo
+     * @return ObjectIdentifier
+     * @throws \RuntimeException
+     */
+    public static function getHashAlgorithmOid($hashAlgo)
+    {
+        if (array_key_exists($hashAlgo, self::$oidMap)) {
+            $oidString = self::$oidMap[$hashAlgo];
+            return new ObjectIdentifier($oidString);
+        }
+
+        throw new \InvalidArgumentException('Unsupported hashing algorithm.');
+    }
+
+    /**
+     * @param MathAdapterInterface $math
+     * @param ObjectIdentifier $oid
+     * @return Hasher
+     */
+    public static function getHasherFromOid(MathAdapterInterface $math, ObjectIdentifier $oid)
+    {
+        $oidString = $oid->getContent();
+        $invertedMap = array_flip(self::$oidMap);
+
+        if (array_key_exists($oidString, $invertedMap)) {
+            $hashAlgorithm = $invertedMap[$oidString];
+            return new Hasher($math, $hashAlgorithm);
+        }
+
+        throw new \InvalidArgumentException('Unsupported hashing algorithm.');
+    }
+}

--- a/src/Util/Hasher.php
+++ b/src/Util/Hasher.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Mdanter\Ecc\Util;
+
+
+use Mdanter\Ecc\Math\MathAdapterInterface;
+
+class Hasher
+{
+    /**
+     * @var string
+     */
+    private $algo;
+
+    /**
+     * @var MathAdapterInterface
+     */
+    private $math;
+
+    /**
+     * @param MathAdapterInterface $math
+     * @param string $algo
+     */
+    public function __construct(MathAdapterInterface $math, $algo)
+    {
+        if (!in_array($algo, hash_algos())) {
+            throw new \InvalidArgumentException('Hashing algorithm not known');
+        }
+
+        $this->algo = $algo;
+        $this->math = $math;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlgo()
+    {
+        return $this->algo;
+    }
+
+    /**
+     * @param $string - a binary string to hash
+     * @param bool|false $binary
+     * @return string
+     */
+    public function hash($string, $binary = false)
+    {
+        return hash($this->algo, $string, $binary);
+    }
+
+    /**
+     * Hash the data, returning a decimal.
+     *
+     * @param $string - a binary string to hash
+     * @return int|string
+     */
+    public function hashDec($string)
+    {
+        $hex = $this->hash($string, false);
+        return $this->math->hexDec($hex);
+    }
+}

--- a/tests/unit/Primitives/EcDomainTest.php
+++ b/tests/unit/Primitives/EcDomainTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Primitives;
+
+
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Primitives\EcDomain;
+use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+use Mdanter\Ecc\Util\Hasher;
+
+class EcDomainTest extends AbstractTestCase
+{
+    public function testEcDomain()
+    {
+        $algo = 'sha256';
+        $name = 'secp256k1';
+        $math = new Gmp();
+        $curve = CurveFactory::getCurveByName($name);
+        $generator = CurveFactory::getGeneratorByName($name);
+        $hasher = new Hasher($math, $algo);
+        $domain = new EcDomain($math, $curve, $generator, $hasher);
+
+        $this->assertEquals($hasher, $domain->getHasher());
+        $this->assertEquals($generator, $domain->getGenerator());
+        $this->assertEquals($curve, $domain->getCurve());
+        $this->assertEquals('ecdsa+' . $algo, $domain->getSigAlgorithm());
+        $this->assertInstanceOf(Signer::class, $domain->getSigner());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testEcDomainWithBadCombination()
+    {
+        $algo = 'sha256';
+        $math = new Gmp();
+        $curve = CurveFactory::getCurveByName('secp256k1');
+        $generator = CurveFactory::getGeneratorByName('nist-p521');
+        $hasher = new Hasher($math, $algo);
+
+        new EcDomain($math, $curve, $generator, $hasher);
+    }
+
+    public function testFactoryMethod()
+    {
+        $curveName = 'secp256k1';
+        $hashAlgorithm = 'sha256';
+        $domain = EccFactory::getDomain($curveName, $hashAlgorithm);
+        $this->assertInstanceOf(EcDomain::class, $domain);
+
+        $this->assertEquals($curveName, $domain->getCurve()->getName());
+    }
+}

--- a/tests/unit/Serializer/Curves/EcParamsOidSerializerTest.php
+++ b/tests/unit/Serializer/Curves/EcParamsOidSerializerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Serializer\Curves;
+
+
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Serializer\Curves\EcParamsOidSerializer;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class EcParamsOidSerializerTest extends AbstractTestCase
+{
+    public function getVectors()
+    {
+        return [
+            [
+                'secp112r1',
+                '-----BEGIN EC PARAMETERS-----
+BgUrgQQABg==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'secp256k1',
+                '-----BEGIN EC PARAMETERS-----
+BgUrgQQACg==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'secp256r1',
+                '-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'secp384r1',
+                '-----BEGIN EC PARAMETERS-----
+BgUrgQQAIg==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p192',
+                '-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBAQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p224',
+                '-----BEGIN EC PARAMETERS-----
+BgUrgQQAIQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p256',
+                '-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p384',
+                '-----BEGIN EC PARAMETERS-----
+BgUrgQQAIg==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p521',
+                '-----BEGIN EC PARAMETERS-----
+BgUrgQQAIw==
+-----END EC PARAMETERS-----'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getVectors
+     */
+    public function testAgainstOpenSSL($curveName, $expectedParams)
+    {
+        $math = EccFactory::getAdapter();
+        $curve = CurveFactory::getCurveByName($curveName);
+        $G = CurveFactory::getGeneratorByName($curveName);
+
+        $ser = new EcParamsOidSerializer();
+        $this->assertEquals($expectedParams, $ser->serialize($curve));
+    }
+}

--- a/tests/unit/Serializer/Curves/EcParamsSerializerTest.php
+++ b/tests/unit/Serializer/Curves/EcParamsSerializerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Serializer\Curves;
+
+
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Serializer\Curves\EcParamsOidSerializer;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class EcParamsSerializerTest extends AbstractTestCase
+{
+    public function getVectors()
+    {
+        return [
+            [
+                'secp112r1',
+                '-----BEGIN EC PARAMETERS-----
+MIGLAgEBMBoGByqGSM49AQECDwDbfCq/YuNeZoB2vq0gizA3BA7bfCq/YuNeZoB2
+vq0giAQOZZ74ugQ5Fu7eiRFwKyIDFQAA9QsCjk1pbmdodWFRdSkEcng/sQQdBAlI
+cjmZWl7na1X5wvCYqJzlr4ckwKI+Dg/3dQACDwDbfCq/YuNedijfrGVhxQIBAQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'secp256k1',
+                '-----BEGIN EC PARAMETERS-----
+MIGiAgEBMCwGByqGSM49AQECIQD////////////////////////////////////+
+///8LzAGBAEABAEHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hI
+Otp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP//////////////////
+//66rtzmr0igO7/SXozQNkFBAgEB
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'secp256r1',
+                '-----BEGIN EC PARAMETERS-----
+MIH3AgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP//////////
+/////zBbBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12Ko6
+k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsDFQDEnTYIhucEk2pmeOETnSa3gZ9+
+kARBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLeszoPShOUXYmMKWT+NC4v4af5uO5+tK
+fA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////AAAAAP//////////vOb6racXnoTz
+ucrC/GMlUQIBAQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'secp384r1',
+                '-----BEGIN EC PARAMETERS-----
+MIIBVwIBATA8BgcqhkjOPQEBAjEA////////////////////////////////////
+//////7/////AAAAAAAAAAD/////MHsEMP//////////////////////////////
+///////////+/////wAAAAAAAAAA/////AQwszEvp+I+5+SYjgVr4/gtGRgdnG7+
+gUESAxQIj1ATh1rGVjmNii7RnSqFyO3T7CrvAxUAozWSaqMZonodAIlqZ3OkgnrN
+rHMEYQSqh8oivosFN46xxx7zIK10bh07Younm5hZ90HgglQqOFUC8l2/VSlsOlRe
+OHJ2Crc2F95KliYsb12emL+Sktwp+PQdvSiaFHzp2jETtfC4wApgsc4dfoGdekMd
+fJDqDl8CMQD////////////////////////////////HY02B9Dct31gaDbJIsKd6
+7OwZaszFKXMCAQE=
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p192',
+                '-----BEGIN EC PARAMETERS-----
+MIHHAgEBMCQGByqGSM49AQECGQD////////////////////+//////////8wSwQY
+/////////////////////v/////////8BBhkIQUZ5ZyA5w+n6atyJDBJ/rje7MFG
+ubEDFQAwRa5vyEIvZO1XlSjTgSDq4SGW1QQxBBiNqA6wMJD2fL8g60OhiAD0/wr9
+gv8QEgcZK5X/yNp4YxAR7WskzdVz+XehHnlIEQIZAP///////////////5ne+DYU
+a8mxtNIoMQIBAQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p224',
+                '-----BEGIN EC PARAMETERS-----
+MIHfAgEBMCgGByqGSM49AQECHQD/////////////////////AAAAAAAAAAAAAAAB
+MFMEHP////////////////////7///////////////4EHLQFCoUMBLOr9UEyVlBE
+sLfXv9i6Jws5QyNV/7QDFQC9cTRHmdXH/NxFtZ+juauPapSLxQQ5BLcODL1rtL9/
+MhOQuUoDwdNWwhEiNDKA1hFcHSG9N2OItfcj+0wi3+bNQ3WgWgdHZETVgZmFAH40
+Ah0A//////////////////8WouC48D4T3SlFXFwqPQIBAQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p256',
+                '-----BEGIN EC PARAMETERS-----
+MIH3AgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP//////////
+/////zBbBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12Ko6
+k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsDFQDEnTYIhucEk2pmeOETnSa3gZ9+
+kARBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLeszoPShOUXYmMKWT+NC4v4af5uO5+tK
+fA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////AAAAAP//////////vOb6racXnoTz
+ucrC/GMlUQIBAQ==
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p384',
+                '-----BEGIN EC PARAMETERS-----
+MIIBVwIBATA8BgcqhkjOPQEBAjEA////////////////////////////////////
+//////7/////AAAAAAAAAAD/////MHsEMP//////////////////////////////
+///////////+/////wAAAAAAAAAA/////AQwszEvp+I+5+SYjgVr4/gtGRgdnG7+
+gUESAxQIj1ATh1rGVjmNii7RnSqFyO3T7CrvAxUAozWSaqMZonodAIlqZ3OkgnrN
+rHMEYQSqh8oivosFN46xxx7zIK10bh07Younm5hZ90HgglQqOFUC8l2/VSlsOlRe
+OHJ2Crc2F95KliYsb12emL+Sktwp+PQdvSiaFHzp2jETtfC4wApgsc4dfoGdekMd
+fJDqDl8CMQD////////////////////////////////HY02B9Dct31gaDbJIsKd6
+7OwZaszFKXMCAQE=
+-----END EC PARAMETERS-----'
+            ],
+            [
+                'nist-p521',
+                '-----BEGIN EC PARAMETERS-----
+MIIBwgIBATBNBgcqhkjOPQEBAkIB////////////////////////////////////
+//////////////////////////////////////////////////8wgZ4EQgH/////
+////////////////////////////////////////////////////////////////
+/////////////////ARBUZU+uWGOHJofkpohoLaFQO6i2nJbmbMV87i0iZGO8Qnh
+Vhk5Uex+k3sWUsC9O7G/BzVz34g9LDTx70Uf1GtQPwADFQDQnogAKRy4U5bMZxc5
+MoSqoNpkugSBhQQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5BT+1Ifgor2BrTT26oUte
+d+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYBGDkpaniaO8AEXIpftCx9G9mY
+9URJV5tEaBevvRcnPmYsl+5ymV70JkDFULkBP60HYTU8cIaicsJAiL6Udp/RZlAC
+QgH///////////////////////////////////////////pRhoeDvy+Wa3/MAUj3
+CaXQO7XJuImcR667b7cekThkCQIBAQ==
+-----END EC PARAMETERS-----'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getVectors
+     */
+    public function testAgainstOpenSSL($curveName, $expectedParams)
+    {
+        $math = EccFactory::getAdapter();
+        $curve = CurveFactory::getCurveByName($curveName);
+        $G = CurveFactory::getGeneratorByName($curveName);
+
+        $pSer = new \Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer($math);
+        $ser = new \Mdanter\Ecc\Serializer\Curves\EcParamsSerializer($pSer);
+
+        $this->assertEquals($expectedParams, $ser->serialize($curve, $G));
+    }
+}

--- a/tests/unit/Serializer/Util/HashAlgorithmOidMapperTest.php
+++ b/tests/unit/Serializer/Util/HashAlgorithmOidMapperTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Serializer\Util;
+
+
+use FG\ASN1\Universal\ObjectIdentifier;
+use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+use Mdanter\Ecc\Serializer\Util\HashAlgorithmOidMapper;
+
+class HashAlgorithmOidMapperTest extends AbstractTestCase
+{
+    public function testGetNames()
+    {
+        $names = array(
+            'sha1',
+            'sha224',
+            'sha256',
+            'sha384',
+            'sha512'
+        );
+
+        $this->assertEquals($names, HashAlgorithmOidMapper::getNames());
+    }
+
+    public function testGetOid()
+    {
+        $algo = 'sha256';
+        $oid = HashAlgorithmOidMapper::getHashAlgorithmOid($algo);
+        $this->assertEquals('2.16.840.1.101.3.4.2.1', $oid->getContent());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetOidButUnkown()
+    {
+        $algo = 'sha25000';
+        $oid = HashAlgorithmOidMapper::getHashAlgorithmOid($algo);
+        $this->assertEquals('2.16.840.1.101.3.4.2.1', $oid->getContent());
+    }
+
+    public function testGetHasher()
+    {
+        $algo = 'sha256';
+        $math = new Gmp();
+        $oid = HashAlgorithmOidMapper::getHashAlgorithmOid($algo);
+        $hasher = HashAlgorithmOidMapper::getHasherFromOid($math, $oid);
+        $this->assertEquals($algo, $hasher->getAlgo());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetHasherButUnkown()
+    {
+        $math = new Gmp();
+        $oid = new ObjectIdentifier('1.1.1');
+        HashAlgorithmOidMapper::getHasherFromOid($math, $oid);
+    }
+
+    public function testGetByteSize()
+    {
+        $this->assertEquals(64, HashAlgorithmOidMapper::getByteSize('sha256'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetByteSizeButUnkown()
+    {
+        HashAlgorithmOidMapper::getByteSize('sha256aaaaa');
+    }
+}

--- a/tests/unit/Util/HasherTest.php
+++ b/tests/unit/Util/HasherTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Util;
+
+
+use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+use Mdanter\Ecc\Util\Hasher;
+
+class HasherTest extends AbstractTestCase
+{
+    public function testHash()
+    {
+        $math = new Gmp();
+        $algo = 'sha256';
+        $hasher = new Hasher($math, $algo);
+
+        $expected = hash('sha256', 'test');
+        $hash = $hasher->hash('test');
+        $this->assertEquals($expected, $hash);
+
+        $expected = hash('sha256', 'test', false);
+        $hash = $hasher->hash('test', false);
+        $this->assertEquals($expected, $hash);
+
+        $expected = hash('sha256', 'test', true);
+        $hash = $hasher->hash('test', true);
+        $this->assertEquals($expected, $hash);
+
+        $this->assertEquals($algo, $hasher->getAlgo());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidAlgo()
+    {
+        $math = new Gmp();
+        new Hasher($math, 'sha127');
+    }
+}


### PR DESCRIPTION
This adds an EcDomain class, which captures a choice of Curve/Generator/Hasher. (A new Hasher class is added, limited to the ones we have support and have the corresponding OID's). 

An EcParamsSerializer, and EcParamsOidSerializer are included, which match openssl on most points. 

It did lead me to discover we have duplicated entries for some curves. most of the nist-p*** curves are secp*r1. This is apparent in the CurveOidMapper after adding the missing curves..

Anyways, I believe this class to be useful, since ECDSA really requires knowledge of the hashing algorithm and generator order, etc. 

This PR is first in a series, I'll provide clearer 'diff' links in subsequent ones for easy review. 