### PR TITLE
Introduce size parameter in curves

### DIFF
--- a/src/Curves/NamedCurveFp.php
+++ b/src/Curves/NamedCurveFp.php
@@ -4,6 +4,7 @@ namespace Mdanter\Ecc\Curves;
 
 use Mdanter\Ecc\Primitives\CurveFp;
 use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Primitives\CurveParameters;
 
 class NamedCurveFp extends CurveFp
 {
@@ -14,16 +15,14 @@ class NamedCurveFp extends CurveFp
 
     /**
      * @param int|string           $name
-     * @param int|string           $prime
-     * @param int|string           $a
-     * @param MathAdapterInterface $b
+     * @param CurveParameters      $parameters
      * @param MathAdapterInterface $adapter
      */
-    public function __construct($name, $prime, $a, $b, MathAdapterInterface $adapter)
+    public function __construct($name, CurveParameters $parameters, MathAdapterInterface $adapter)
     {
         $this->name = $name;
 
-        parent::__construct($prime, $a, $b, $adapter);
+        parent::__construct($parameters, $adapter);
     }
 
     /**

--- a/src/Curves/NistCurve.php
+++ b/src/Curves/NistCurve.php
@@ -166,7 +166,7 @@ class NistCurve
         $p = '39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319';
         $b = $this->adapter->hexDec('0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef');
 
-        $parameters = new CurveParameters(256, $p, -3, $b);
+        $parameters = new CurveParameters(384, $p, -3, $b);
 
         return new NamedCurveFp(self::NAME_P384, $parameters, $this->adapter);
     }

--- a/src/Curves/NistCurve.php
+++ b/src/Curves/NistCurve.php
@@ -3,6 +3,7 @@ namespace Mdanter\Ecc\Curves;
 
 use Mdanter\Ecc\Primitives\CurveFp;
 use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\CurveParameters;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
 use Mdanter\Ecc\Math\MathAdapterInterface;
 use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
@@ -69,7 +70,9 @@ class NistCurve
         $p = '6277101735386680763835789423207666416083908700390324961279';
         $b = $this->adapter->hexDec('0x64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1');
 
-        return new NamedCurveFp(self::NAME_P192, $p, -3, $b, $this->adapter);
+        $parameters = new CurveParameters(192, $p, -3, $b);
+
+        return new NamedCurveFp(self::NAME_P192, $parameters, $this->adapter);
     }
 
     /**
@@ -99,7 +102,9 @@ class NistCurve
         $p = '26959946667150639794667015087019630673557916260026308143510066298881';
         $b = $this->adapter->hexDec('0xb4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4');
 
-        return new NamedCurveFp(self::NAME_P224, $p, -3, $b, $this->adapter);
+        $parameters = new CurveParameters(224, $p, -3, $b);
+
+        return new NamedCurveFp(self::NAME_P224, $parameters, $this->adapter);
     }
 
     /**
@@ -129,7 +134,9 @@ class NistCurve
         $p = '115792089210356248762697446949407573530086143415290314195533631308867097853951';
         $b = $this->adapter->hexDec('0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b');
 
-        return new NamedCurveFp(self::NAME_P256, $p, -3, $b, $this->adapter);
+        $parameters = new CurveParameters(256, $p, -3, $b);
+
+        return new NamedCurveFp(self::NAME_P256, $parameters, $this->adapter);
     }
 
     /**
@@ -159,7 +166,9 @@ class NistCurve
         $p = '39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319';
         $b = $this->adapter->hexDec('0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef');
 
-        return new NamedCurveFp(self::NAME_P384, $p, -3, $b, $this->adapter);
+        $parameters = new CurveParameters(256, $p, -3, $b);
+
+        return new NamedCurveFp(self::NAME_P384, $parameters, $this->adapter);
     }
 
     /**
@@ -189,7 +198,9 @@ class NistCurve
         $p = '6864797660130609714981900799081393217269435300143305409394463459185543183397656052122559640661454554977296311391480858037121987999716643812574028291115057151';
         $b = $this->adapter->hexDec('0x051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00');
 
-        return new NamedCurveFp(self::NAME_P521, $p, -3, $b, $this->adapter);
+        $parameters = new CurveParameters(521, $p, -3, $b);
+
+        return new NamedCurveFp(self::NAME_P521, $parameters, $this->adapter);
     }
 
     /**

--- a/src/Curves/SecgCurve.php
+++ b/src/Curves/SecgCurve.php
@@ -3,6 +3,7 @@
 namespace Mdanter\Ecc\Curves;
 
 use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Primitives\CurveParameters;
 use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
 
 /**
@@ -61,7 +62,9 @@ class SecgCurve
         $a = $this->adapter->hexDec('0xDB7C2ABF62E35E668076BEAD2088');
         $b = $this->adapter->hexDec('0x659EF8BA043916EEDE8911702B22');
 
-        return new NamedCurveFp(self::NAME_SECP_112R1, $p, $a, $b, $this->adapter);
+        $parameters = new CurveParameters(112, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_112R1, $parameters, $this->adapter);
     }
 
     /**
@@ -88,7 +91,9 @@ class SecgCurve
         $a = 0;
         $b = 7;
 
-        return new NamedCurveFp(self::NAME_SECP_256K1, $p, $a, $b, $this->adapter);
+        $parameters = new CurveParameters(256, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_256K1, $parameters, $this->adapter);
     }
 
     /**
@@ -115,7 +120,9 @@ class SecgCurve
         $a = $this->adapter->hexDec('0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC');
         $b = $this->adapter->hexDec('0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B');
 
-        return new NamedCurveFp(self::NAME_SECP_256R1, $p, $a, $b, $this->adapter);
+        $parameters = new CurveParameters(256, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_256R1, $parameters, $this->adapter);
     }
 
     /**
@@ -142,7 +149,9 @@ class SecgCurve
         $a = $this->adapter->hexDec('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFF0000000000000000FFFFFFFC');
         $b = $this->adapter->hexDec('0xB3312FA7E23EE7E4988E056BE3F82D19181D9C6EFE8141120314088F5013875AC656398D8A2ED19D2A85C8EDD3EC2AEF');
 
-        return new NamedCurveFp(self::NAME_SECP_384R1, $p, $a, $b, $this->adapter);
+        $parameters = new CurveParameters(384, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_384R1, $parameters, $this->adapter);
     }
 
     /**

--- a/src/Message/EncryptedMessage.php
+++ b/src/Message/EncryptedMessage.php
@@ -2,7 +2,6 @@
 
 namespace Mdanter\Ecc\Message;
 
-
 class EncryptedMessage
 {
     /**

--- a/src/Primitives/CurveFp.php
+++ b/src/Primitives/CurveFp.php
@@ -36,24 +36,11 @@ use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
  */
 class CurveFp implements CurveFpInterface
 {
-    /**
-     * Elliptic curve over the field of integers modulo a prime.
-     *
-     * @var int|string
-     */
-    protected $a = 0;
 
     /**
-     *
-     * @var int|string
+     * @var CurveParameters
      */
-    protected $b = 0;
-
-    /**
-     *
-     * @var int|string
-     */
-    protected $prime = 0;
+    protected $parameters;
 
     /**
      *
@@ -70,18 +57,14 @@ class CurveFp implements CurveFpInterface
     /**
      * Constructor that sets up the instance variables.
      *
-     * @param $prime int|string
-     * @param $a int|string
-     * @param $b int|string
+     * @param $parameters CurveParameters
      * @param $adapter MathAdapterInterface
      */
-    public function __construct($prime, $a, $b, MathAdapterInterface $adapter)
+    public function __construct(CurveParameters $parameters, MathAdapterInterface $adapter)
     {
-        $this->a = $a;
-        $this->b = $b;
-        $this->prime = $prime;
+        $this->parameters = $parameters;
         $this->adapter = $adapter;
-        $this->modAdapter = new ModularArithmetic($this->adapter, $prime);
+        $this->modAdapter = new ModularArithmetic($this->adapter, $this->parameters->getPrime());
     }
 
     /**
@@ -128,7 +111,7 @@ class CurveFp implements CurveFpInterface
     {
         $math = $this->adapter;
 
-        $eq_zero = $math->cmp($math->mod($math->sub($math->pow($y, 2), $math->add($math->add($math->pow($x, 3), $math->mul($this->a, $x)), $this->b)), $this->prime), 0);
+        $eq_zero = $math->cmp($math->mod($math->sub($math->pow($y, 2), $math->add($math->add($math->pow($x, 3), $math->mul($this->getA(), $x)), $this->getB())), $this->getPrime()), 0);
 
         return ($eq_zero == 0);
     }
@@ -139,7 +122,7 @@ class CurveFp implements CurveFpInterface
      */
     public function getA()
     {
-        return $this->a;
+        return $this->parameters->getA();
     }
 
     /**
@@ -148,7 +131,7 @@ class CurveFp implements CurveFpInterface
      */
     public function getB()
     {
-        return $this->b;
+        return $this->parameters->getB();
     }
 
     /**
@@ -157,7 +140,15 @@ class CurveFp implements CurveFpInterface
      */
     public function getPrime()
     {
-        return $this->prime;
+        return $this->parameters->getPrime();
+    }
+
+    /**
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->parameters->getSize();
     }
 
     /**
@@ -168,9 +159,9 @@ class CurveFp implements CurveFpInterface
     {
         $math = $this->adapter;
 
-        $equal  = ($math->cmp($this->a, $other->getA()) == 0);
-        $equal &= ($math->cmp($this->b, $other->getB()) == 0);
-        $equal &= ($math->cmp($this->prime, $other->getPrime()) == 0);
+        $equal  = ($math->cmp($this->getA(), $other->getA()) == 0);
+        $equal &= ($math->cmp($this->getB(), $other->getB()) == 0);
+        $equal &= ($math->cmp($this->getPrime(), $other->getPrime()) == 0);
 
         return ($equal) ? 0 : 1;
     }
@@ -190,7 +181,7 @@ class CurveFp implements CurveFpInterface
      */
     public function __toString()
     {
-        return 'curve('.$this->a.', '.$this->b.', '.$this->prime.')';
+        return 'curve(' . $this->getA() . ', ' . $this->getB() . ', ' . $this->getPrime() . ')';
     }
 
     /**
@@ -199,9 +190,9 @@ class CurveFp implements CurveFpInterface
     public function __debugInfo()
     {
         return [
-            'a' => (string) $this->a,
-            'b' => (string) $this->b,
-            'prime' => (string) $this->prime
+            'a' => (string) $this->getA(),
+            'b' => (string) $this->getB(),
+            'prime' => (string) $this->getPrime()
         ];
     }
 }

--- a/src/Primitives/CurveFpInterface.php
+++ b/src/Primitives/CurveFpInterface.php
@@ -100,6 +100,11 @@ interface CurveFpInterface
     public function getPrime();
 
     /**
+     * @return int
+     */
+    public function getSize();
+
+    /**
      * Compares the curve to another.
      *
      * @param  CurveFpInterface $other

--- a/src/Primitives/CurveParameters.php
+++ b/src/Primitives/CurveParameters.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+class CurveParameters
+{
+    /**
+     * Elliptic curve over the field of integers modulo a prime.
+     *
+     * @var int|string
+     */
+    protected $a = 0;
+
+    /**
+     *
+     * @var int|string
+     */
+    protected $b = 0;
+
+    /**
+     *
+     * @var int|string
+     */
+    protected $prime = 0;
+
+    /**
+     * Binary length of keys associated with these curve parameters
+     *
+     * @var int
+     */
+    protected $size = 0;
+
+    /**
+     * @param int $size
+     * @param int|string $prime
+     * @param int|string $a
+     * @param int|string $b
+     */
+    public function __construct($size, $prime, $a, $b)
+    {
+        $this->size = $size;
+        $this->prime = $prime;
+        $this->a = $a;
+        $this->b = $b;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getA()
+    {
+        return $this->a;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getB()
+    {
+        return $this->b;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getPrime()
+    {
+        return $this->prime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+}

--- a/src/Primitives/Point.php
+++ b/src/Primitives/Point.php
@@ -264,8 +264,8 @@ class Point implements PointInterface
             clone $this
         ];
 
-        $n = $this->adapter->baseConvert($n, 10, 2);
-        $k = strlen($n);
+        $k = $this->curve->getSize();
+        $n = str_pad($this->adapter->baseConvert($n, 10, 2), $k, '0', STR_PAD_LEFT);
 
         for ($i = 0; $i < $k; $i++) {
             $j = $n[$i];

--- a/tests/unit/Primitives/EcArithmeticTest.php
+++ b/tests/unit/Primitives/EcArithmeticTest.php
@@ -3,6 +3,7 @@
 namespace Mdanter\Ecc\Tests\Primitives;
 
 use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Primitives\CurveParameters;
 use Mdanter\Ecc\Primitives\Point;
 use Mdanter\Ecc\Primitives\CurveFp;
 use Mdanter\Ecc\Primitives\CurveFpInterface;
@@ -29,7 +30,8 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testAdditions(MathAdapterInterface $math)
     {
-        $curve = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $curve = new CurveFp($parameters, $math);
 
         $this->add($math, $curve, 3, 10, 9, 7, 17, 20);
     }
@@ -41,7 +43,8 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testAdditionCommutativity(MathAdapterInterface $math)
     {
-        $curve = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $curve = new CurveFp($parameters, $math);
 
         $p1 = $curve->getPoint(3, 10);
         $p2 = $curve->getPoint(9, 7);
@@ -51,7 +54,7 @@ class EcArithmeticTest extends AbstractTestCase
 
         $this->assertTrue($p3a == $p4a);
 
-        $c = new CurveFp(23, 1, 1, $math);
+        $c = new CurveFp($parameters, $math);
         $g = $c->getPoint(13, 7, 7);
         $check = $c->getInfinity();
 
@@ -71,7 +74,9 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testDouble(MathAdapterInterface $math)
     {
-        $c = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $c = new CurveFp($parameters, $math);
+
         $x1 = 3;
         $y1 = 10;
         $x3 = 7;
@@ -91,7 +96,8 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testAddDouble(MathAdapterInterface $math)
     {
-        $c = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $c = new CurveFp($parameters, $math);
 
         $this->add($math, $c, 3, 10, 3, 10, 7, 12);
     }
@@ -102,7 +108,9 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testMultiply(MathAdapterInterface $math)
     {
-        $c = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $c = new CurveFp($parameters, $math);
+
         $x1 = 3;
         $y1 = 10;
         $m = 2;
@@ -140,7 +148,8 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testMultiply2(MathAdapterInterface $math, $p, $a, $b, $x, $y, $m, $ex, $ey)
     {
-        $c = new CurveFp($p, $a, $b, $math);
+        $parameters = new CurveParameters(32, $p, $a, $b);
+        $c = new CurveFp($parameters, $math);
 
         $p1 = $c->getPoint($x, $y);
         $p3 = $p1->mul($m);
@@ -157,7 +166,9 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testMultiplyAssociative(MathAdapterInterface $math)
     {
-        $c = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $c = new CurveFp($parameters, $math);
+
         $g = $c->getPoint(13, 7, null);
 
         $a = $g->mul('1234564564564564564564564564564564646')->mul(10);
@@ -172,7 +183,9 @@ class EcArithmeticTest extends AbstractTestCase
      */
     public function testInfinity(MathAdapterInterface $math)
     {
-        $c = new CurveFp(23, 1, 1, $math);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $c = new CurveFp($parameters, $math);
+
         $g = $c->getPoint(13, 7, 7);
 
         $check = $c->getInfinity();

--- a/tests/unit/Primitives/PointTest.php
+++ b/tests/unit/Primitives/PointTest.php
@@ -3,6 +3,7 @@
 namespace Mdanter\Ecc\Tests\Primitives;
 
 use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Primitives\CurveParameters;
 use Mdanter\Ecc\Primitives\Point;
 use Mdanter\Ecc\Primitives\CurveFp;
 use Mdanter\Ecc\Tests\AbstractTestCase;
@@ -12,7 +13,9 @@ class PointTest extends AbstractTestCase
     public function testAddInfinityReturnsOriginalPoint()
     {
         $adapter = new Gmp();
-        $curve = new CurveFp(23, 1, 1, $adapter);
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $curve = new CurveFp($parameters, $adapter);
+
         $infinity = $curve->getInfinity();
 
         $point = new Point($adapter, $curve, 13, 7, 7);
@@ -30,7 +33,10 @@ class PointTest extends AbstractTestCase
         $a = '104564512312317874865';
         $b = '04156456456456456456';
 
-        $curve = new CurveFp(23, 1, 1, new Gmp());
+        $adapter = new Gmp();
+        $parameters = new CurveParameters(32, 23, 1, 1);
+        $curve = new CurveFp($parameters, $adapter);
+
         $point = $curve->getPoint(13, 7, 7);
 
         $point->cswapValue($a, $b, false);


### PR DESCRIPTION
As discussed in #97 and #98, point multiplication is not done in constant time which leaks the key through side channel attacks.

This (partially) fixes the issue by introducing a size parameter to perform point multiplication in constant time for a given parameter set.