### PR TITLE
Der signature serializer

### DIFF
--- a/src/Message/EncryptedMessage.php
+++ b/src/Message/EncryptedMessage.php
@@ -2,7 +2,6 @@
 
 namespace Mdanter\Ecc\Message;
 
-
 class EncryptedMessage
 {
     /**

--- a/src/Serializer/Signature/Der/Formatter.php
+++ b/src/Serializer/Signature/Der/Formatter.php
@@ -2,7 +2,6 @@
 
 namespace Mdanter\Ecc\Serializer\Signature\Der;
 
-
 use FG\ASN1\Universal\Integer;
 use FG\ASN1\Universal\Sequence;
 use Mdanter\Ecc\Crypto\Signature\SignatureInterface;

--- a/src/Serializer/Signature/Der/Formatter.php
+++ b/src/Serializer/Signature/Der/Formatter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature\Der;
+
+
+use FG\ASN1\Universal\Integer;
+use FG\ASN1\Universal\Sequence;
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+class Formatter
+{
+    /**
+     * @param SignatureInterface $signature
+     * @return Sequence
+     */
+    public function toAsn(SignatureInterface $signature)
+    {
+        return new Sequence(
+            new Integer($signature->getR()),
+            new Integer($signature->getS())
+        );
+    }
+
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature)
+    {
+        return $this->toAsn($signature)->getBinary();
+    }
+}

--- a/src/Serializer/Signature/Der/Parser.php
+++ b/src/Serializer/Signature/Der/Parser.php
@@ -2,7 +2,6 @@
 
 namespace Mdanter\Ecc\Serializer\Signature\Der;
 
-
 use FG\ASN1\Identifier;
 use FG\ASN1\Object;
 use Mdanter\Ecc\Crypto\Signature\Signature;

--- a/src/Serializer/Signature/Der/Parser.php
+++ b/src/Serializer/Signature/Der/Parser.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature\Der;
+
+
+use FG\ASN1\Identifier;
+use FG\ASN1\Object;
+use Mdanter\Ecc\Crypto\Signature\Signature;
+
+class Parser
+{
+    /**
+     * @param string $binary
+     * @return Signature
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function parse($binary)
+    {
+        $object = Object::fromBinary($binary);
+        if ($object->getType() !== Identifier::SEQUENCE) {
+            throw new \RuntimeException('Failed to parse signature');
+        }
+
+        $content = $object->getContent();
+        if (count($content) !== 2) {
+            throw new \RuntimeException('Failed to parse signature');
+        }
+
+        /** @var \FG\ASN1\Universal\Integer $r  */
+        /** @var \FG\ASN1\Universal\Integer $s  */
+        list ($r, $s) = $content;
+        if ($r->getType() !== Identifier::INTEGER || $s->getType() !== Identifier::INTEGER) {
+            throw new \RuntimeException('Failed to parse signature');
+        }
+
+        return new Signature(
+            $r->getContent(),
+            $s->getContent()
+        );
+    }
+}

--- a/src/Serializer/Signature/DerSignatureSerializer.php
+++ b/src/Serializer/Signature/DerSignatureSerializer.php
@@ -2,7 +2,6 @@
 
 namespace Mdanter\Ecc\Serializer\Signature;
 
-
 use Mdanter\Ecc\Crypto\Signature\Signature;
 use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
 

--- a/src/Serializer/Signature/DerSignatureSerializer.php
+++ b/src/Serializer/Signature/DerSignatureSerializer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature;
+
+
+use Mdanter\Ecc\Crypto\Signature\Signature;
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+class DerSignatureSerializer
+{
+    /**
+     * @var Der\Parser
+     */
+    private $parser;
+
+    /**
+     * @var Der\Formatter
+     */
+    private $formatter;
+
+    /**
+     *
+     */
+    public function __construct()
+    {
+        $this->parser = new Der\Parser();
+        $this->formatter = new Der\Formatter();
+    }
+
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature)
+    {
+        return $this->formatter->serialize($signature);
+    }
+
+    /**
+     * @param string $binary
+     * @return Signature
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function parse($binary)
+    {
+        return $this->parser->parse($binary);
+    }
+}

--- a/tests/unit/Serializer/DerSignatureSerializerTest.php
+++ b/tests/unit/Serializer/DerSignatureSerializerTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: aeonium
- * Date: 24/09/15
- * Time: 13:49
- */
 
 namespace Mdanter\Ecc\Tests\Serializer;
 

--- a/tests/unit/Serializer/DerSignatureSerializerTest.php
+++ b/tests/unit/Serializer/DerSignatureSerializerTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: aeonium
+ * Date: 24/09/15
+ * Time: 13:49
+ */
+
+namespace Mdanter\Ecc\Tests\Serializer;
+
+
+use Mdanter\Ecc\Crypto\Signature\Signature;
+use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Random\RandomGeneratorFactory;
+use Mdanter\Ecc\Serializer\Signature\DerSignatureSerializer;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class DerSignatureSerializerTest extends AbstractTestCase
+{
+    public function testParsesSignature()
+    {
+        $r = '15012732708734045374201164973195778115424038544478436215140305923518805725225';
+        $s = '32925333523544781093325025052915296870609904100588287156912210086353851961511';
+        $expected = strtolower('304402202130E7D504C4A498C3B3C7C0FED6DE2A84811A3BD89BADB8627658F2B1EA5029022048CB1410308E3EFC512B4CE0974F6D0869E9454095C8855ABEA6B6325A40D0A7');
+        $signature = new Signature($r, $s);
+        $serializer = new DerSignatureSerializer();
+        $serialized = bin2hex($serializer->serialize($signature));
+        $this->assertEquals($expected, $serialized);
+    }
+
+    public function testIsConsistent()
+    {
+        $math = new Gmp();
+        $rbg = RandomGeneratorFactory::getUrandomGenerator();
+        $serializer = new DerSignatureSerializer();
+
+        for ($i = 2; $i <= 521; $i++) {
+            $max = $math->sub($math->pow(2, $i), 1);
+            $r = $rbg->generate($max);
+            $s = $rbg->generate($max);
+            $signature = new Signature($r, $s);
+
+            $serialized = $serializer->serialize($signature);
+            $parsed = $serializer->parse($serialized);
+
+            $this->assertEquals($signature, $parsed);
+        }
+    }
+}


### PR DESCRIPTION
Adds a DerSignatureSerializer. This is the representation openssl will use for signing data. Seems useful to have it here - it was only possible after PHPASN1's Integer class could tolerate big-int's. 