### PR TITLE
Allow this library to be used on Symfony3 projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "ext-gmp": "*",
         "ext-mcrypt": "*",
         "fgrosse/phpasn1": "~1.3.1",
-        "symfony/console": "~2.6"
+        "symfony/console": "~2.6|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1",
+        "phpunit/phpunit": "~4.1|~5.0",
         "squizlabs/php_codesniffer": "~2",
-        "symfony/yaml": "~2.6"
+        "symfony/yaml": "~2.6|~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/unit/Curves/SpecBasedCurveTest.php
+++ b/tests/unit/Curves/SpecBasedCurveTest.php
@@ -41,7 +41,7 @@ class SpecBasedCurveTest extends AbstractTestCase
         $datasets = [];
 
         foreach ($files as $file) {
-            $data = $yaml->parse($file);
+            $data = $yaml->parse(file_get_contents($file));
             $generator = CurveFactory::getGeneratorByName($data['name']);
 
             foreach ($data['keypairs'] as $testKeyPair) {
@@ -86,7 +86,7 @@ class SpecBasedCurveTest extends AbstractTestCase
         $datasets = [];
 
         foreach ($files as $file) {
-            $data = $yaml->parse($file);
+            $data = $yaml->parse(file_get_contents($file));
             $generator = CurveFactory::getGeneratorByName($data['name']);
 
             foreach ($data['diffie'] as $testKeyPair) {
@@ -133,7 +133,7 @@ class SpecBasedCurveTest extends AbstractTestCase
         $datasets = [];
 
         foreach ($files as $file) {
-            $data = $yaml->parse($file);
+            $data = $yaml->parse(file_get_contents($file));
 
             if (! isset($data['hmac'])) {
                 continue;


### PR DESCRIPTION
See https://github.com/phpecc/phpecc/pull/116 for background

Had to add to this, as Yaml::parse() no longer accepts file names. 