### PR TITLE
No need for symfony console anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
         "php": ">=5.4.0",
         "ext-gmp": "*",
         "ext-mcrypt": "*",
-        "fgrosse/phpasn1": "~1.3.1",
-        "symfony/console": "~2.6|~3.0"
+        "fgrosse/phpasn1": "~1.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1|~5.0",


### PR DESCRIPTION
Since Console components have moved to `phpecc/console`