### PR TITLE
Add PHPASN bignum compatibility

### DIFF
--- a/src/Serializer/Signature/Der/BignumInt.php
+++ b/src/Serializer/Signature/Der/BignumInt.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature\Der;
+
+use Exception;
+use FG\ASN1\Object;
+use FG\ASN1\Parsable;
+use FG\ASN1\Identifier;
+
+class BignumInt extends Object implements Parsable
+{
+    /** @var int */
+    private $value;
+
+    /**
+     * @param int $value
+     *
+     * @throws Exception if the value is not numeric
+     */
+    public function __construct($value)
+    {
+        if (is_numeric($value) == false) {
+            throw new Exception("Invalid VALUE [{$value}] for ASN1_INTEGER");
+        }
+        $this->value = $value;
+    }
+
+    public function getType()
+    {
+        return Identifier::INTEGER;
+    }
+
+    public function getContent()
+    {
+        return $this->value;
+    }
+
+    protected function calculateContentLength()
+    {
+        $nrOfOctets = 1; // we need at least one octet
+        $tmpValue = gmp_abs(gmp_init($this->value, 10));
+        while (gmp_cmp($tmpValue, 127) > 0) {
+            $tmpValue = $this->rightShift($tmpValue, 8);
+            $nrOfOctets++;
+        }
+        return $nrOfOctets;
+    }
+
+    /**
+     * @param resource|\GMP $number
+     * @param int $positions
+     *
+     * @return resource|\GMP
+     */
+    private function rightShift($number, $positions)
+    {
+        // Shift 1 right = div / 2
+        return gmp_div($number, gmp_pow(2, (int) $positions));
+    }
+
+    protected function getEncodedValue()
+    {
+        $numericValue = gmp_init($this->value, 10);
+        $contentLength = $this->getContentLength();
+
+        if (gmp_sign($numericValue) < 0) {
+            $numericValue = gmp_add($numericValue, (gmp_sub(gmp_pow(2, 8 * $contentLength), 1)));
+            $numericValue = gmp_add($numericValue, 1);
+        }
+
+        $result = '';
+        for ($shiftLength = ($contentLength - 1) * 8; $shiftLength >= 0; $shiftLength -= 8) {
+            $octet = gmp_strval(gmp_mod($this->rightShift($numericValue, $shiftLength), 256));
+            $result .= chr($octet);
+        }
+
+        return $result;
+    }
+
+    public static function fromBinary(&$binaryData, &$offsetIndex = 0)
+    {
+        $parsedObject = new static(0);
+        self::parseIdentifier($binaryData[$offsetIndex], $parsedObject->getType(), $offsetIndex++);
+        $contentLength = self::parseContentLength($binaryData, $offsetIndex, 1);
+
+        $isNegative = (ord($binaryData[$offsetIndex]) & 0x80) != 0x00;
+        $number = gmp_init(ord($binaryData[$offsetIndex++]) & 0x7F, 10);
+
+        for ($i = 0; $i < $contentLength - 1; $i++) {
+            $number = gmp_or(gmp_mul($number, 0x100), ord($binaryData[$offsetIndex++]));
+        }
+
+        if ($isNegative) {
+            $number = gmp_sub($number, gmp_pow(2, 8 * $contentLength - 1));
+        }
+
+        $parsedObject = new static(gmp_strval($number, 10));
+        $parsedObject->setContentLength($contentLength);
+
+        return $parsedObject;
+    }
+}

--- a/src/Serializer/Signature/Der/BignumObjectParser.php
+++ b/src/Serializer/Signature/Der/BignumObjectParser.php
@@ -1,0 +1,322 @@
+<?php
+/*
+ * This file is part of the PHPASN1 library.
+ *
+ * Copyright © Friedrich Große <friedrich.grosse@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mdanter\Ecc\Serializer\Signature\Der;
+
+use FG\ASN1\Exception\ParserException;
+use FG\ASN1\Universal\BitString;
+use FG\ASN1\Universal\Boolean;
+use FG\ASN1\Universal\Enumerated;
+use FG\ASN1\Universal\GeneralizedTime;
+use FG\ASN1\Universal\Integer;
+use FG\ASN1\Universal\NullObject;
+use FG\ASN1\Universal\ObjectIdentifier;
+use FG\ASN1\Universal\RelativeObjectIdentifier;
+use FG\ASN1\Universal\OctetString;
+use FG\ASN1\Universal\Sequence;
+use FG\ASN1\Universal\Set;
+use FG\ASN1\Universal\UTCTime;
+use FG\ASN1\Universal\IA5String;
+use FG\ASN1\Universal\PrintableString;
+use FG\ASN1\Universal\NumericString;
+use FG\ASN1\Universal\UTF8String;
+use FG\ASN1\Universal\UniversalString;
+use FG\ASN1\Universal\CharacterString;
+use FG\ASN1\Universal\GeneralString;
+use FG\ASN1\Universal\VisibleString;
+use FG\ASN1\Universal\GraphicString;
+use FG\ASN1\Universal\BMPString;
+use FG\ASN1\Universal\T61String;
+use FG\ASN1\Universal\ObjectDescriptor;
+use FG\ASN1\Parsable;
+use FG\ASN1\Identifier;
+use LogicException;
+
+/**
+ * Class Object is the base class for all concrete ASN.1 objects.
+ */
+abstract class BignumObjectParser implements Parsable
+{
+    private $contentLength;
+    private $nrOfLengthOctets;
+
+    /**
+     * Must return the number of octets of the content part
+     * @return int
+     */
+    abstract protected function calculateContentLength();
+
+    /**
+     * Encode the object using DER encoding
+     * @see http://en.wikipedia.org/wiki/X.690#DER_encoding
+     * @return string the binary representation of an objects value
+     */
+    abstract protected function getEncodedValue();
+
+    /**
+     * Return the content of this object in a non encoded form.
+     * This can be used to print the value in human readable form
+     * @return mixed
+     */
+    abstract public function getContent();
+
+    /**
+     * Return the object type octet.
+     * This should use the class constants of Identifier
+     * @see Identifier
+     * @return int
+     */
+    abstract public function getType();
+
+    /**
+     * Returns all identifier octets. If an inheriting class models a tag with
+     * the long form identifier format, it MUST reimplement this method to
+     * return all octets of the identifier.
+     *
+     * @return string Identifier as a set of octets
+     * @throws LogicException If the identifier format is long form
+     */
+    public function getIdentifier()
+    {
+        $firstOctet = $this->getType();
+
+        if (Identifier::isLongForm($firstOctet)) {
+            throw new LogicException(sprintf('Identifier of %s uses the long form and must therefor override "Object::getIdentifier()".', get_class($this)));
+        }
+
+        return chr($firstOctet);
+    }
+
+    /**
+     * Encode this object using DER encoding
+     * @return string the full binary representation of the complete object
+     */
+    public function getBinary()
+    {
+        $result  = $this->getIdentifier();
+        $result .= $this->createLengthPart();
+        $result .= $this->getEncodedValue();
+
+        return $result;
+    }
+
+    private function createLengthPart()
+    {
+        $contentLength = $this->getContentLength();
+        $nrOfLengthOctets = $this->getNumberOfLengthOctets($contentLength);
+
+        if ($nrOfLengthOctets == 1) {
+            return chr($contentLength);
+        } else {
+            // the first length octet determines the number subsequent length octets
+            $lengthOctets = chr(0x80 | ($nrOfLengthOctets-1));
+            for ($shiftLength = 8*($nrOfLengthOctets-2); $shiftLength >= 0; $shiftLength -= 8) {
+                $lengthOctets .= chr($contentLength >> $shiftLength);
+            }
+
+            return $lengthOctets;
+        }
+    }
+
+    protected function getNumberOfLengthOctets($contentLength = null)
+    {
+        if (!isset($this->nrOfLengthOctets)) {
+            if ($contentLength == null) {
+                $contentLength = $this->getContentLength();
+            }
+
+            $this->nrOfLengthOctets = 1;
+            if ($contentLength > 127) {
+                do { // long form
+                    $this->nrOfLengthOctets++;
+                    $contentLength = $contentLength >> 8;
+                } while ($contentLength > 0);
+            }
+        }
+
+        return $this->nrOfLengthOctets;
+    }
+
+    protected function getContentLength()
+    {
+        if (!isset($this->contentLength)) {
+            $this->contentLength = $this->calculateContentLength();
+        }
+
+        return $this->contentLength;
+    }
+
+    protected function setContentLength($newContentLength)
+    {
+        $this->contentLength = $newContentLength;
+        $this->getNumberOfLengthOctets($newContentLength);
+    }
+
+    /**
+     * Returns the length of the whole object (including the identifier and length octets).
+     */
+    public function getObjectLength()
+    {
+        $nrOfIdentifierOctets = strlen($this->getIdentifier());
+        $contentLength = $this->getContentLength();
+        $nrOfLengthOctets = $this->getNumberOfLengthOctets($contentLength);
+
+        return $nrOfIdentifierOctets + $nrOfLengthOctets + $contentLength;
+    }
+
+    public function __toString()
+    {
+        return $this->getContent();
+    }
+
+    /**
+     * Returns the name of the ASN.1 Type of this object.
+     *
+     * @see Identifier::getName()
+     */
+    public function getTypeName()
+    {
+        return Identifier::getName($this->getType());
+    }
+
+    /**
+     * @param string $binaryData
+     * @param int $offsetIndex
+     * @return \FG\ASN1\Object
+     * @throws ParserException
+     */
+    public static function fromBinary(&$binaryData, &$offsetIndex = 0)
+    {
+        if (strlen($binaryData) < $offsetIndex) {
+            throw new ParserException("Can not parse binary from data: Offset index larger than input size", $offsetIndex);
+        }
+
+        $identifierOctet = ord($binaryData[$offsetIndex]);
+        if (Identifier::isContextSpecificClass($identifierOctet) && Identifier::isConstructed($identifierOctet)) {
+            return ExplicitlyTaggedObject::fromBinary($binaryData, $offsetIndex);
+        }
+
+        switch ($identifierOctet) {
+            case Identifier::BITSTRING:
+                return BitString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::BOOLEAN:
+                return Boolean::fromBinary($binaryData, $offsetIndex);
+            case Identifier::ENUMERATED:
+                return Enumerated::fromBinary($binaryData, $offsetIndex);
+            case Identifier::INTEGER:
+                return BignumInt::fromBinary($binaryData, $offsetIndex);
+            case Identifier::NULL:
+                return NullObject::fromBinary($binaryData, $offsetIndex);
+            case Identifier::OBJECT_IDENTIFIER:
+                return ObjectIdentifier::fromBinary($binaryData, $offsetIndex);
+            case Identifier::RELATIVE_OID:
+                return RelativeObjectIdentifier::fromBinary($binaryData, $offsetIndex);
+            case Identifier::OCTETSTRING:
+                return OctetString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::SEQUENCE:
+                return Sequence::fromBinary($binaryData, $offsetIndex);
+            case Identifier::SET:
+                return Set::fromBinary($binaryData, $offsetIndex);
+            case Identifier::UTC_TIME:
+                return UTCTime::fromBinary($binaryData, $offsetIndex);
+            case Identifier::GENERALIZED_TIME:
+                return GeneralizedTime::fromBinary($binaryData, $offsetIndex);
+            case Identifier::IA5_STRING:
+                return IA5String::fromBinary($binaryData, $offsetIndex);
+            case Identifier::PRINTABLE_STRING:
+                return PrintableString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::NUMERIC_STRING:
+                return NumericString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::UTF8_STRING:
+                return UTF8String::fromBinary($binaryData, $offsetIndex);
+            case Identifier::UNIVERSAL_STRING:
+                return UniversalString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::CHARACTER_STRING:
+                return CharacterString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::GENERAL_STRING:
+                return GeneralString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::VISIBLE_STRING:
+                return VisibleString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::GRAPHIC_STRING:
+                return GraphicString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::BMP_STRING:
+                return BMPString::fromBinary($binaryData, $offsetIndex);
+            case Identifier::T61_STRING:
+                return T61String::fromBinary($binaryData, $offsetIndex);
+            case Identifier::OBJECT_DESCRIPTOR:
+                return ObjectDescriptor::fromBinary($binaryData, $offsetIndex);
+            default:
+                // At this point the identifier may be >1 byte.
+                if (Identifier::isConstructed($identifierOctet)) {
+                    return new UnknownConstructedObject($binaryData, $offsetIndex);
+                } else {
+
+                    $identifier = self::parseBinaryIdentifier($binaryData, $offsetIndex);
+                    $lengthOfUnknownObject = self::parseContentLength($binaryData, $offsetIndex);
+                    $offsetIndex += $lengthOfUnknownObject;
+
+                    return new UnknownObject($identifier, $lengthOfUnknownObject);
+                }
+        }
+    }
+
+    protected static function parseIdentifier($identifierOctet, $expectedIdentifier, $offsetForExceptionHandling)
+    {
+        if (is_string($identifierOctet) || is_numeric($identifierOctet) == false) {
+            $identifierOctet = ord($identifierOctet);
+        }
+
+        if ($identifierOctet != $expectedIdentifier) {
+            $message = 'Can not create an '.Identifier::getName($expectedIdentifier).' from an '.Identifier::getName($identifierOctet);
+            throw new ParserException($message, $offsetForExceptionHandling);
+        }
+    }
+
+    protected static function parseBinaryIdentifier($binaryData, &$offsetIndex)
+    {
+        $identifier = $binaryData[$offsetIndex++];
+
+        if (Identifier::isLongForm(ord($identifier)) == false) {
+            return $identifier;
+        }
+
+        while (true) {
+            $nextOctet = $binaryData[$offsetIndex++];
+            $identifier .= $nextOctet;
+
+            if ((ord($nextOctet) & 0x80) === 0) {
+                // the most significant bit is 0 to we have reached the end of the identifier
+                break;
+            }
+        }
+
+        return $identifier;
+    }
+
+    protected static function parseContentLength(&$binaryData, &$offsetIndex, $minimumLength = 0)
+    {
+        $contentLength = ord($binaryData[$offsetIndex++]);
+
+        if (($contentLength & 0x80) != 0) {
+            // bit 8 is set -> this is the long form
+            $nrOfLengthOctets = $contentLength & 0x7F;
+            $contentLength = 0x00;
+            for ($i = 0; $i < $nrOfLengthOctets; $i++) {
+                $contentLength = ($contentLength << 8) + ord($binaryData[$offsetIndex++]);
+            }
+        }
+
+        if ($contentLength < $minimumLength) {
+            throw new ParserException('A '.get_called_class()." should have a content length of at least {$minimumLength}. Extracted length was {$contentLength}", $offsetIndex);
+        }
+
+        return $contentLength;
+    }
+}

--- a/src/Serializer/Signature/Der/Formatter.php
+++ b/src/Serializer/Signature/Der/Formatter.php
@@ -15,8 +15,8 @@ class Formatter
     public function toAsn(SignatureInterface $signature)
     {
         return new Sequence(
-            new Integer($signature->getR()),
-            new Integer($signature->getS())
+            new BignumInt($signature->getR()),
+            new BignumInt($signature->getS())
         );
     }
 

--- a/src/Serializer/Signature/Der/Parser.php
+++ b/src/Serializer/Signature/Der/Parser.php
@@ -3,7 +3,6 @@
 namespace Mdanter\Ecc\Serializer\Signature\Der;
 
 use FG\ASN1\Identifier;
-use FG\ASN1\Object;
 use Mdanter\Ecc\Crypto\Signature\Signature;
 
 class Parser
@@ -15,7 +14,7 @@ class Parser
      */
     public function parse($binary)
     {
-        $object = Object::fromBinary($binary);
+        $object = BignumObjectParser::fromBinary($binary);
         if ($object->getType() !== Identifier::SEQUENCE) {
             throw new \RuntimeException('Failed to parse signature');
         }


### PR DESCRIPTION
A while ago I patched PHPASN1 with big-integer support, but it looks like that wound up in a php5.6+ branch. This PR adds the Integer class I wrote, and an Object parser patched to use this over the 1.3.1 Integer implementation. 

This PR should fix the test suite, we can jump to the latest PHPASN1 when another version of PHP reaches EOL. 

(There is a tagged branch that includes the Integer class, but it's marked dev, so we'd have to change our minimum compatibility setting)