### PR TITLE
Point::cswapValue() Use inline calls to gmp_*

### DIFF
--- a/src/Primitives/Point.php
+++ b/src/Primitives/Point.php
@@ -303,18 +303,22 @@ class Point implements PointInterface
      */
     public function cswapValue(& $a, & $b, $cond)
     {
+
         $size = max(strlen($this->adapter->baseConvert($a, 10, 2)), strlen($this->adapter->baseConvert($b, 10, 2)));
 
         $mask = 1 - intval($cond);
         $mask = str_pad('', $size, $mask, STR_PAD_LEFT);
-        $mask = $this->adapter->baseConvert($mask, 2, 10);
+        $mask = gmp_init($mask ?: 0, 2);
 
-        $tA = $this->adapter->bitwiseAnd($a, $mask);
-        $tB = $this->adapter->bitwiseAnd($b, $mask);
+        $taA = gmp_and(gmp_init($a, 10), $mask);
+        $taB = gmp_and(gmp_init($b, 10), $mask);
 
-        $a = $this->adapter->bitwiseXor($this->adapter->bitwiseXor($a, $b), $tB);
-        $b = $this->adapter->bitwiseXor($this->adapter->bitwiseXor($a, $b), $tA);
-        $a = $this->adapter->bitwiseXor($this->adapter->bitwiseXor($a, $b), $tB);
+        $a = gmp_xor(gmp_xor(gmp_init($a,10), gmp_init($b,10)), $taB);
+        $b = gmp_xor(gmp_xor($a, gmp_init($b,10)), $taA);
+        $a = gmp_xor(gmp_xor($a, $b), $taB);
+
+        $a = gmp_strval($a, 10);
+        $b = gmp_strval($b, 10);
     }
 
     /**


### PR DESCRIPTION
I was looking for easy targets to try improve point multiplications performance. Point::cswapValue() does the legwork for the conditional swap, and is used 2 * `curve_bit_size` times per multiplication. Since it only uses the Math adapter, I wondered if the avoiding the adapter and it's gmp_init() .. gmp_strval() motif would yield a performance gain (see #79).

## Testing
The numbers for using gmp_* calls directly look great. The results that follow are the runtime of 50 scalar multiplications against the generator point, using PHP 5.6, with xdebug disabled.

Nistp521: 11.923877954483 vs 9.6763050556183 (18.84% improvement)
Nistp256: 4.1276268959045 vs 3.2799549102783 (20.5% improvement)
Secp256k1: 3.9668779373169 vs 3.3589730262756 (15.32% improvement)

I checked the test suite next: 53.22 seconds against 0cb2c74, and 42.2 seconds against this PR.

## Thoughts
The cost of gmp_init() / gmp_strval for every mathematical operation is pretty heavy. The 15-20% gain in avoiding this is pretty attractive, and a good indicator that we should rethink the MathAdapterInterface. 

The double-add-always algorithm effectively doubles the cost of a scalar multiplication, and because of this, some users have preferred to remain at 0.2. This is unfortunate - since double-add-always was added for good reason - the next step ought to be continuing to optimize the library.

## Future work
I believe the library should start using \GMP instances instead of int|string. The MathAdapterInterface should be replaced/rewritten, or we might simply write the calls to GMP inline. I have a mild preference for the former, though don't really mind. 