### PR TITLE
CompressedPointSerializer

### DIFF
--- a/src/Math/NumberTheory.php
+++ b/src/Math/NumberTheory.php
@@ -269,37 +269,4 @@ class NumberTheory
         throw new \InvalidArgumentException('Unable to calculate square root mod p!');
 
     }
-
-    /**
-     * @param CurveFpInterface $curve
-     * @param bool $wasOdd
-     * @param \GMP $xCoord
-     * @return \GMP
-     */
-    public function recoverYfromX(CurveFpInterface $curve, $wasOdd, $xCoord)
-    {
-        $math = $this->adapter;
-        $prime = $curve->getPrime();
-
-        $root = $this->squareRootModP(
-            $math->add(
-                $math->add(
-                    $math->powmod(
-                        $xCoord,
-                        gmp_init(3, 10),
-                        $prime
-                    ),
-                    $math->mul($curve->getA(), $xCoord)
-                ),
-                $curve->getB()
-            ),
-            $prime
-        );
-
-        if ($math->equals($math->mod($root, gmp_init(2, 10)), gmp_init(1)) === $wasOdd) {
-            return $root;
-        } else {
-            return $math->sub($prime, $root);
-        }
-    }
 }

--- a/src/Math/NumberTheory.php
+++ b/src/Math/NumberTheory.php
@@ -29,6 +29,7 @@ namespace Mdanter\Ecc\Math;
  *
  * @author Matyas Danter
  */
+use Mdanter\Ecc\Primitives\CurveFpInterface;
 
 /**
  * Rewritten to take a MathAdaptor to handle different environments. Has
@@ -181,8 +182,7 @@ class NumberTheory
         $two = gmp_init(2, 10);
         $four = gmp_init(4, 10);
         $eight = gmp_init(8, 10);
-
-        if ($math->cmp($zero, $a) <= 0 && $math->cmp($a, $p) < 0 && $math->cmp($one, $p) < 0) {
+        if ($math->cmp($one, $p) < 0) {
             if ($math->equals($a, $zero)) {
                 return $zero;
             }
@@ -192,7 +192,6 @@ class NumberTheory
             }
 
             $jac = $math->jacobi($a, $p);
-
             if ($jac == -1) {
                 throw new \LogicException($math->toString($a)." has no square root modulo ".$math->toString($p));
             }
@@ -235,7 +234,7 @@ class NumberTheory
                 //shouldn't get here
             }
 
-            for ($b = gmp_init(2, 10); $math->cmp($b, $p) < 0; $b = gmp_add($b, 1)) {
+            for ($b = gmp_init(2, 10); $math->cmp($b, $p) < 0; $b = gmp_add($b, gmp_init(1, 10))) {
                 if ($math->jacobi(
                     $math->sub(
                         $math->mul($b, $b),
@@ -269,5 +268,38 @@ class NumberTheory
 
         throw new \InvalidArgumentException('Unable to calculate square root mod p!');
 
+    }
+
+    /**
+     * @param CurveFpInterface $curve
+     * @param bool $wasOdd
+     * @param \GMP $xCoord
+     * @return \GMP
+     */
+    public function recoverYfromX(CurveFpInterface $curve, $wasOdd, $xCoord)
+    {
+        $math = $this->adapter;
+        $prime = $curve->getPrime();
+
+        $root = $this->squareRootModP(
+            $math->add(
+                $math->add(
+                    $math->powmod(
+                        $xCoord,
+                        gmp_init(3, 10),
+                        $prime
+                    ),
+                    $math->mul($curve->getA(), $xCoord)
+                ),
+                $curve->getB()
+            ),
+            $prime
+        );
+
+        if ($math->equals($math->mod($root, gmp_init(2, 10)), gmp_init(1)) === $wasOdd) {
+            return $root;
+        } else {
+            return $math->sub($prime, $root);
+        }
     }
 }

--- a/src/Primitives/CurveFp.php
+++ b/src/Primitives/CurveFp.php
@@ -104,6 +104,37 @@ class CurveFp implements CurveFpInterface
     }
 
     /**
+     * @param bool $wasOdd
+     * @param \GMP $xCoord
+     * @return \GMP
+     */
+    public function recoverYfromX($wasOdd, \GMP $xCoord)
+    {
+        $math = $this->adapter;
+        $prime = $this->getPrime();
+
+        $root = $this->adapter->getNumberTheory()->squareRootModP(
+            $math->add(
+                $math->add(
+                    $math->powmod(
+                        $xCoord,
+                        gmp_init(3, 10),
+                        $prime
+                    ),
+                    $math->mul($this->getA(), $xCoord)
+                ),
+                $this->getB()
+            ),
+            $prime
+        );
+
+        if ($math->equals($math->mod($root, gmp_init(2, 10)), gmp_init(1)) === $wasOdd) {
+            return $root;
+        } else {
+            return $math->sub($prime, $root);
+        }
+    }
+    /**
      * {@inheritDoc}
      * @see \Mdanter\Ecc\CurveFpInterface::contains()
      */

--- a/src/Primitives/CurveFpInterface.php
+++ b/src/Primitives/CurveFpInterface.php
@@ -53,6 +53,13 @@ interface CurveFpInterface
     public function getPoint(\GMP $x, \GMP $y, \GMP $order = null);
 
     /**
+     * @param bool $wasOdd
+     * @param \GMP $x
+     * @return \GMP
+     */
+    public function recoverYfromX($wasOdd, \GMP $x);
+
+    /**
      * Returns a point representing infinity on the curve.
      *
      * @return PointInterface

--- a/src/Serializer/Point/CompressedPointSerializer.php
+++ b/src/Serializer/Point/CompressedPointSerializer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Point;
+
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Primitives\PointInterface;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+
+class CompressedPointSerializer
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var \Mdanter\Ecc\Math\NumberTheory
+     */
+    private $theory;
+
+    /**
+     * CompressedPointSerializer constructor.
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+        $this->theory = $adapter->getNumberTheory();
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return string
+     */
+    public function serialize(PointInterface $point)
+    {
+        $math = $this->adapter;
+        $prefix = $math->equals($math->mod($point->getY(), gmp_init(2, 10)), gmp_init(0)) ? '02' : '03';
+        $length = CurveOidMapper::getByteSize($point->getCurve()) * 2;
+
+        $hexString = $prefix;
+        $hexString .= str_pad(gmp_strval($point->getX(), 16), $length, '0', STR_PAD_LEFT);
+
+        return $hexString;
+    }
+
+    /**
+     * @param CurveFpInterface $curve
+     * @param string $data - hex serialized compressed point
+     * @return PointInterface
+     */
+    public function unserialize(CurveFpInterface $curve, $data)
+    {
+        $prefix = substr($data, 0, 2);
+
+        $x = gmp_init(substr($data, 2), 16);
+        $y = $this->theory->recoverYfromX($curve, $prefix === '03', $x);
+
+        return $curve->getPoint($x, $y);
+    }
+}

--- a/src/Serializer/Point/CompressedPointSerializer.php
+++ b/src/Serializer/Point/CompressedPointSerializer.php
@@ -5,7 +5,6 @@ namespace Mdanter\Ecc\Serializer\Point;
 
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Primitives\CurveFpInterface;
-use Mdanter\Ecc\Primitives\GeneratorPoint;
 use Mdanter\Ecc\Primitives\PointInterface;
 use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
 
@@ -35,13 +34,24 @@ class CompressedPointSerializer
      * @param PointInterface $point
      * @return string
      */
+    public function getPrefix(PointInterface $point)
+    {
+        if ($this->adapter->equals($this->adapter->mod($point->getY(), gmp_init(2, 10)), gmp_init(0))) {
+            return '02';
+        } else {
+            return '03';
+        }
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return string
+     */
     public function serialize(PointInterface $point)
     {
-        $math = $this->adapter;
-        $prefix = $math->equals($math->mod($point->getY(), gmp_init(2, 10)), gmp_init(0)) ? '02' : '03';
         $length = CurveOidMapper::getByteSize($point->getCurve()) * 2;
 
-        $hexString = $prefix;
+        $hexString = $this->getPrefix($point);
         $hexString .= str_pad(gmp_strval($point->getX(), 16), $length, '0', STR_PAD_LEFT);
 
         return $hexString;
@@ -57,7 +67,7 @@ class CompressedPointSerializer
         $prefix = substr($data, 0, 2);
 
         $x = gmp_init(substr($data, 2), 16);
-        $y = $this->theory->recoverYfromX($curve, $prefix === '03', $x);
+        $y = $curve->recoverYfromX($prefix === '03', $x);
 
         return $curve->getPoint($x, $y);
     }

--- a/tests/unit/Curves/SpecBasedCurveTest.php
+++ b/tests/unit/Curves/SpecBasedCurveTest.php
@@ -2,7 +2,9 @@
 
 namespace Mdanter\Ecc\Tests\Curves;
 
+use Mdanter\Ecc\Math\NumberTheory;
 use Mdanter\Ecc\Random\RandomGeneratorFactory;
+use Mdanter\Ecc\Serializer\Point\CompressedPointSerializer;
 use Mdanter\Ecc\Tests\AbstractTestCase;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
 use Symfony\Component\Yaml\Yaml;
@@ -72,6 +74,11 @@ class SpecBasedCurveTest extends AbstractTestCase
 
         $this->assertEquals($adapter->hexDec($expectedX), $adapter->toString($publicKey->getPoint()->getX()), $name);
         $this->assertEquals($adapter->hexDec($expectedY), $adapter->toString($publicKey->getPoint()->getY()), $name);
+
+        $compressor = new CompressedPointSerializer($adapter);
+        $serialized = $compressor->serialize($publicKey->getPoint());
+        $parsed = $compressor->unserialize($generator->getCurve(), $serialized);
+        $this->assertTrue($parsed->equals($publicKey->getPoint()));
     }
 
     /**


### PR DESCRIPTION
Elliptic curve points can be serialized in a compressed notation. The y coordinate can be solved and determined on from only the x-coordinate, and an optionally set bit in the prefix. 

A new method was added to NumberTheory for this: `recoverYfromX`. Also the new class: `CompressedPointSerializer`, which is tested for against each curve/key vector we have for consistence.

I may have stumbled on a bug in NumberTheory developing this since initially, many calls to `squareRootModP` failed. It turned out that method threw upon $a < 0. After removing this check, the method correctly generated the right point. 