### PR TITLE
Tests added on the PHP 7 nightly branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
     - nightly
     - hhvm
 
-matrix:
-    allow_failures:
-        - php: nightly
-
 sudo: false
 
 env:
@@ -30,3 +26,5 @@ after_success:
 
 matrix:
     fast_finish: true
+    allow_failures:
+        - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ language: php
 
 php:
     - 5.6
-    - 7
+    - 7.0
+    - nightly
     - hhvm
+
+matrix:
+    allow_failures:
+        - php: nightly
 
 sudo: false
 


### PR DESCRIPTION
This PR adds test to be performed on the PHP 7 nightly branch.
As it is an unstable branch, the tests are allowed to fail.
