### PR TITLE
Number theory & CurveFp: use ModularArithmetic

### DIFF
--- a/src/Math/ModularArithmetic.php
+++ b/src/Math/ModularArithmetic.php
@@ -61,7 +61,7 @@ class ModularArithmetic
      */
     public function div(\GMP $dividend, \GMP $divisor)
     {
-        return $this->adapter->mod($this->adapter->mul($dividend, $this->adapter->inverseMod($divisor, $this->modulus)), $this->modulus);
+        return $this->mul($dividend, $this->adapter->inverseMod($divisor, $this->modulus));
     }
 
     /**

--- a/src/Math/NumberTheory.php
+++ b/src/Math/NumberTheory.php
@@ -181,6 +181,8 @@ class NumberTheory
         $two = gmp_init(2, 10);
         $four = gmp_init(4, 10);
         $eight = gmp_init(8, 10);
+
+        $modMath = $math->getModularArithmetic($p);
         if ($math->cmp($one, $p) < 0) {
             if ($math->equals($a, $zero)) {
                 return $zero;
@@ -196,38 +198,34 @@ class NumberTheory
             }
 
             if ($math->equals($math->mod($p, $four), gmp_init(3, 10))) {
-                return $math->powmod($a, $math->div($math->add($p, $one), $four), $p);
+                return $modMath->pow($a, $math->div($math->add($p, $one), $four));
             }
 
             if ($math->equals($math->mod($p, $eight), gmp_init(5, 10))) {
-                $d = $math->powmod($a, $math->div($math->sub($p, $one), $four), $p);
+                $d = $modMath->pow($a, $math->div($math->sub($p, $one), $four));
                 if ($math->equals($d, $one)) {
-                    return $math->powmod($a, $math->div($math->add($p, gmp_init(3, 10)), $eight), $p);
+                    return $modMath->pow($a, $math->div($math->add($p, gmp_init(3, 10)), $eight));
                 }
 
                 if ($math->equals($d, $math->sub($p, $one))) {
-                    return $math->mod(
+                    return $modMath->mul(
                         $math->mul(
+                            $two,
+                            $a
+                        ),
+                        $modMath->pow(
                             $math->mul(
-                                $two,
+                                $four,
                                 $a
                             ),
-                            $math->powmod(
-                                $math->mul(
-                                    $four,
-                                    $a
+                            $math->div(
+                                $math->sub(
+                                    $p,
+                                    gmp_init(5, 10)
                                 ),
-                                $math->div(
-                                    $math->sub(
-                                        $p,
-                                        gmp_init(5, 10)
-                                    ),
-                                    $eight
-                                ),
-                                $p
+                                $eight
                             )
-                        ),
-                        $p
+                        )
                     );
                 }
                 //shouldn't get here

--- a/src/Primitives/CurveFp.php
+++ b/src/Primitives/CurveFp.php
@@ -116,11 +116,7 @@ class CurveFp implements CurveFpInterface
         $root = $this->adapter->getNumberTheory()->squareRootModP(
             $math->add(
                 $math->add(
-                    $math->powmod(
-                        $xCoord,
-                        gmp_init(3, 10),
-                        $prime
-                    ),
+                    $this->modAdapter->pow($xCoord, gmp_init(3, 10)),
                     $math->mul($this->getA(), $xCoord)
                 ),
                 $this->getB()

--- a/src/Primitives/CurveFp.php
+++ b/src/Primitives/CurveFp.php
@@ -139,18 +139,15 @@ class CurveFp implements CurveFpInterface
         $math = $this->adapter;
 
         $eq_zero = $math->equals(
-            $math->mod(
-                $math->sub(
-                    $math->pow($y, 2),
+            $this->modAdapter->sub(
+                $math->pow($y, 2),
+                $math->add(
                     $math->add(
-                        $math->add(
-                            $math->pow($x, 3),
-                            $math->mul($this->getA(), $x)
-                        ),
-                        $this->getB()
-                    )
-                ),
-                $this->getPrime()
+                        $math->pow($x, 3),
+                        $math->mul($this->getA(), $x)
+                    ),
+                    $this->getB()
+                )
             ),
             gmp_init(0, 10)
         );


### PR DESCRIPTION
`ModularArithmetic::pow()` was unused throughout the codebase. This PR replaces calls to `GmpMathInterface::powmod()` with the former, as it removes the $prime parameter. Any other occurrences of `mod(fx(), p)` where `fx = add | sub | mul` were replaced in the same way. 