### PR TITLE
Update composer.json to require paragonie/random_compat@"^1|^2"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.6.0",
         "ext-gmp": "*",
-        "paragonie/random_compat": "1.4.1|2.0.2",
+        "paragonie/random_compat": "^1|^2",
         "fgrosse/phpasn1": "~1.5"
     },
     "require-dev": {


### PR DESCRIPTION
Solve version conflict with other projects by updating the requirement for paragonie/random_compat to a more general "^1|^2".