### PR TITLE
GmpMath::decHex reject negative integers

### DIFF
--- a/src/Math/GmpMath.php
+++ b/src/Math/GmpMath.php
@@ -141,13 +141,11 @@ class GmpMath implements GmpMathInterface
      */
     public function decHex($dec)
     {
-        $hex = gmp_strval(gmp_init($dec, 10), 16);
-
-        if (BinaryString::length($hex) % 2 != 0) {
-            $hex = '0'.$hex;
+        if ($dec < 0) {
+            throw new \InvalidArgumentException('Unable to convert negative integer to hex');
         }
 
-        return $hex;
+        return unpack('H*', $this->intToString(gmp_init($dec)))[1];
     }
 
     /**

--- a/tests/unit/Math/MathTest.php
+++ b/tests/unit/Math/MathTest.php
@@ -52,6 +52,15 @@ class MathTest extends AbstractTestCase
     );
 
     /**
+     * @expectedException  \InvalidArgumentException
+     * @expectedExceptionMessage Unable to convert negative integer to hex
+     */
+    public function testDecHexNegative()
+    {
+        (new GmpMath)->decHex(-1);
+    }
+
+    /**
      * @dataProvider getAdapters
      * @param GmpMathInterface $adapter
      */


### PR DESCRIPTION
decHex currently uses GMP to convert from base10 to base16. The current usage deals with negative numbers by converting the absolute value to hex and prefixing it with the '-' symbol. 

This PR will have decHex reject negative integers entirely, and rely on the `intToString` function from the same class to produce the hex encoding.