### PR TITLE
Remove dependency from UncompressedPointSerializer on GmpMath - Resolves #180

### DIFF
--- a/src/Serializer/Point/UncompressedPointSerializer.php
+++ b/src/Serializer/Point/UncompressedPointSerializer.php
@@ -2,7 +2,6 @@
 
 namespace Mdanter\Ecc\Serializer\Point;
 
-use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Primitives\PointInterface;
 use Mdanter\Ecc\Primitives\CurveFpInterface;
 use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
@@ -10,19 +9,6 @@ use Mdanter\Ecc\Util\BinaryString;
 
 class UncompressedPointSerializer implements PointSerializerInterface
 {
-    /**
-     * @var GmpMathInterface
-     */
-    private $adapter;
-
-    /**
-     * @param GmpMathInterface     $adapter
-     */
-    public function __construct(GmpMathInterface $adapter)
-    {
-        $this->adapter = $adapter;
-    }
-
     /**
      * @param PointInterface $point
      * @return string

--- a/src/Serializer/PublicKey/Der/Formatter.php
+++ b/src/Serializer/PublicKey/Der/Formatter.php
@@ -5,7 +5,6 @@ namespace Mdanter\Ecc\Serializer\PublicKey\Der;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\ObjectIdentifier;
 use FG\ASN1\Universal\BitString;
-use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Primitives\PointInterface;
 use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
 use Mdanter\Ecc\Curves\NamedCurveFp;
@@ -16,12 +15,6 @@ use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
 
 class Formatter
 {
-
-    /**
-     * @var GmpMathInterface
-     */
-    private $adapter;
-
     /**
      * @var UncompressedPointSerializer
      */
@@ -29,12 +22,10 @@ class Formatter
 
     /**
      * Formatter constructor.
-     * @param GmpMathInterface $adapter
      * @param PointSerializerInterface|null $pointSerializer
      */
-    public function __construct(GmpMathInterface $adapter, PointSerializerInterface $pointSerializer = null)
+    public function __construct(PointSerializerInterface $pointSerializer = null)
     {
-        $this->adapter = $adapter;
         $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer();
     }
 

--- a/src/Serializer/PublicKey/Der/Formatter.php
+++ b/src/Serializer/PublicKey/Der/Formatter.php
@@ -35,7 +35,7 @@ class Formatter
     public function __construct(GmpMathInterface $adapter, PointSerializerInterface $pointSerializer = null)
     {
         $this->adapter = $adapter;
-        $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer($adapter);
+        $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer();
     }
 
     /**

--- a/src/Serializer/PublicKey/Der/Parser.php
+++ b/src/Serializer/PublicKey/Der/Parser.php
@@ -33,7 +33,7 @@ class Parser
     public function __construct(GmpMathInterface $adapter, PointSerializerInterface $pointSerializer = null)
     {
         $this->adapter = $adapter;
-        $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer($adapter);
+        $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer();
     }
 
     /**

--- a/src/Serializer/PublicKey/DerPublicKeySerializer.php
+++ b/src/Serializer/PublicKey/DerPublicKeySerializer.php
@@ -43,7 +43,7 @@ class DerPublicKeySerializer implements PublicKeySerializerInterface
     {
         $this->adapter = $adapter ?: MathAdapterFactory::getAdapter();
 
-        $this->formatter = new Formatter($this->adapter);
+        $this->formatter = new Formatter();
         $this->parser = new Parser($this->adapter);
     }
 

--- a/tests/unit/Curves/SpecBasedCurveTest.php
+++ b/tests/unit/Curves/SpecBasedCurveTest.php
@@ -76,7 +76,7 @@ class SpecBasedCurveTest extends AbstractTestCase
         $this->assertEquals($adapter->hexDec($expectedX), $adapter->toString($publicKey->getPoint()->getX()), $name);
         $this->assertEquals($adapter->hexDec($expectedY), $adapter->toString($publicKey->getPoint()->getY()), $name);
 
-        $serializer = new UncompressedPointSerializer($adapter);
+        $serializer = new UncompressedPointSerializer();
         $serialized = $serializer->serialize($publicKey->getPoint());
         $parsed = $serializer->unserialize($generator->getCurve(), $serialized);
         $this->assertTrue($parsed->equals($publicKey->getPoint()));

--- a/tests/unit/Serializer/Point/UncompressedPointSerializerTest.php
+++ b/tests/unit/Serializer/Point/UncompressedPointSerializerTest.php
@@ -16,7 +16,7 @@ class UncompressedPointSerializerTest extends AbstractTestCase
     public function testChecksPrefix()
     {
         $data = '01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-        $serializer = new UncompressedPointSerializer(EccFactory::getAdapter());
+        $serializer = new UncompressedPointSerializer();
         $serializer->unserialize(EccFactory::getNistCurves()->curve192(), $data);
     }
 }


### PR DESCRIPTION
After removing GmpMath from the `UncompressedPointSerializer`, i also found that the `Serializer\PublicKey\Der\Formatter` no longer had a need for it as its only purpose there was to pass it along the the serializer. Removed it from there aswell. If that was a step to far, let me know.

For the serializer, it was the only dependency so removing it shouldn't cause any issues. php will happily ignore it if you pass it to the constructor anyway. For the formatter it wasn't the only dependency, so removing it there will be a bc-break.

The PR is in two commits atm, one for the serializer and one for the formatter. If you want i can rebase them into one.