### PR TITLE
DerPrivateKeySerializer: take DerPublicKeySerializer as a second parameter

### DIFF
--- a/examples/ecdh_exchange.php
+++ b/examples/ecdh_exchange.php
@@ -16,8 +16,9 @@ $adapter = EccFactory::getAdapter();
 $generator = EccFactory::getNistCurves()->generator384();
 $useDerandomizedSignatures = true;
 
-$pemPriv = new PemPrivateKeySerializer(new DerPrivateKeySerializer());
-$pemPub = new PemPublicKeySerializer(new DerPublicKeySerializer());
+$derPub = new DerPublicKeySerializer();
+$pemPub = new PemPublicKeySerializer($derPub);
+$pemPriv = new PemPrivateKeySerializer(new DerPrivateKeySerializer($adapter, $derPub));
 
 # These .pem and .key are for different keys
 $alicePriv = $pemPriv->parse(file_get_contents('../tests/data/openssl-priv.pem'));

--- a/src/Math/NumberTheory.php
+++ b/src/Math/NumberTheory.php
@@ -165,7 +165,6 @@ class NumberTheory
         }
 
         throw new \InvalidArgumentException('Unable to calculate polynomialPowMod');
-
     }
 
     /**
@@ -264,6 +263,5 @@ class NumberTheory
         }
 
         throw new \InvalidArgumentException('Unable to calculate square root mod p!');
-
     }
 }

--- a/src/Serializer/PrivateKey/DerPrivateKeySerializer.php
+++ b/src/Serializer/PrivateKey/DerPrivateKeySerializer.php
@@ -11,7 +11,6 @@ use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Math\MathAdapterFactory;
 use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
-use Mdanter\Ecc\Serializer\PublicKey\PemPublicKeySerializer;
 use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
 use FG\ASN1\ExplicitlyTaggedObject;
 
@@ -37,9 +36,9 @@ class DerPrivateKeySerializer implements PrivateKeySerializerInterface
 
     /**
      * @param GmpMathInterface       $adapter
-     * @param PemPublicKeySerializer $pubKeySerializer
+     * @param DerPublicKeySerializer $pubKeySerializer
      */
-    public function __construct(GmpMathInterface $adapter = null, PemPublicKeySerializer $pubKeySerializer = null)
+    public function __construct(GmpMathInterface $adapter = null, DerPublicKeySerializer $pubKeySerializer = null)
     {
         $this->adapter = $adapter ?: MathAdapterFactory::getAdapter();
         $this->pubKeySerializer = $pubKeySerializer ?: new DerPublicKeySerializer($this->adapter);
@@ -47,7 +46,7 @@ class DerPrivateKeySerializer implements PrivateKeySerializerInterface
 
     /**
      * {@inheritDoc}
-     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::serialize()
+     * @see \Mdanter\Ecc\Serializer\PrivateKey\PrivateKeySerializerInterface::serialize()
      */
     public function serialize(PrivateKeyInterface $key)
     {
@@ -84,7 +83,7 @@ class DerPrivateKeySerializer implements PrivateKeySerializerInterface
     /**
      * @param string $data
      * {@inheritDoc}
-     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::parse()
+     * @see \Mdanter\Ecc\Serializer\PrivateKey\PrivateKeySerializerInterface::parse()
      * @throws \FG\ASN1\Exception\ParserException
      */
     public function parse($data)

--- a/src/Serializer/PrivateKey/PemPrivateKeySerializer.php
+++ b/src/Serializer/PrivateKey/PemPrivateKeySerializer.php
@@ -26,7 +26,7 @@ class PemPrivateKeySerializer implements PrivateKeySerializerInterface
 
     /**
      * {@inheritDoc}
-     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::serialize()
+     * @see \Mdanter\Ecc\Serializer\PrivateKey\PrivateKeySerializerInterface::serialize()
      */
     public function serialize(PrivateKeyInterface $key)
     {
@@ -41,7 +41,7 @@ class PemPrivateKeySerializer implements PrivateKeySerializerInterface
 
     /**
      * {@inheritDoc}
-     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::parse()
+     * @see \Mdanter\Ecc\Serializer\PrivateKey\PrivateKeySerializerInterface::parse()
      */
     public function parse($formattedKey)
     {

--- a/tests/unit/Serializer/PrivateKey/DerPrivateKeySerializerTest.php
+++ b/tests/unit/Serializer/PrivateKey/DerPrivateKeySerializerTest.php
@@ -31,7 +31,7 @@ class DerPrivateKeySerializerTest extends AbstractTestCase
         $G = EccFactory::getNistCurves($adapter)->generator192();
         $key = $G->createPrivateKey();
 
-        $derPrivSerializer = new DerPrivateKeySerializer($adapter);
+        $derPrivSerializer = new DerPrivateKeySerializer($adapter, new DerPublicKeySerializer());
         $serialized = $derPrivSerializer->serialize($key);
         $parsed = $derPrivSerializer->parse($serialized);
         $this->assertTrue($adapter->equals($parsed->getSecret(), $key->getSecret()));
@@ -48,7 +48,7 @@ class DerPrivateKeySerializerTest extends AbstractTestCase
         $key = $G->createPrivateKey();
 
         $derPubSerializer = new DerPublicKeySerializer();
-        $derPrivSerializer = new DerPrivateKeySerializer();
+        $derPrivSerializer = new DerPrivateKeySerializer($adapter, $derPubSerializer);
 
         // I don't actually have a case of a non-v1 key - just substitute self::VERSION with 2
         $privateKeyInfo = new Sequence(


### PR DESCRIPTION
This was unused throughout the codebase, but I've changed the type to DerPublicKeySerializer as it should be (it shouldn't be doing anything with PEM there) and made use of the optional parameter in tests.

Fixes #188 