### PR TITLE
Backport 0.4: Test for invalid points

### DIFF
--- a/tests/unit/Primitives/PointTest.php
+++ b/tests/unit/Primitives/PointTest.php
@@ -3,6 +3,7 @@
 namespace Mdanter\Ecc\Tests\Primitives;
 
 use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Math\GmpMath;
 use Mdanter\Ecc\Primitives\CurveParameters;
 use Mdanter\Ecc\Primitives\Point;
@@ -146,5 +147,18 @@ class PointTest extends AbstractTestCase
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($b));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($a));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Curve curve(-3, 41058363725152142129326129780047268409114441015993725554835256314039467401291, 115792089210356248762697446949407573530086143415290314195533631308867097853951) does not contain point (58449750472625921448203013684212508347339475414040948669953216871973381284903, 50970277084784601725958135138198442242271560603337990589052444638672428978267)
+     */
+    public function testRejectsInvalidPoints()
+    {
+        $x = gmp_init('58449750472625921448203013684212508347339475414040948669953216871973381284903', 10);
+        $y = gmp_init('50970277084784601725958135138198442242271560603337990589052444638672428978267', 10);
+
+        $generator = EccFactory::getNistCurves()->generator256();
+        $generator->getPublicKeyFrom($x, $y);
     }
 }


### PR DESCRIPTION
 https://blogs.adobe.com/security/2017/03/critical-vulnerability-uncovered-in-json-encryption.html see original PR: #198 