### PR TITLE
Updated to use fgrosse/phpasn1 v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=7.0",
         "ext-gmp": "*",
-        "fgrosse/phpasn1": "^1.5"
+        "fgrosse/phpasn1": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/src/Serializer/PrivateKey/DerPrivateKeySerializer.php
+++ b/src/Serializer/PrivateKey/DerPrivateKeySerializer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Serializer\PrivateKey;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Sequence;
 use FG\ASN1\Universal\Integer;
 use FG\ASN1\Universal\BitString;
@@ -88,7 +88,7 @@ class DerPrivateKeySerializer implements PrivateKeySerializerInterface
      */
     public function parse(string $data): PrivateKeyInterface
     {
-        $asnObject = Object::fromBinary($data);
+        $asnObject = ASNObject::fromBinary($data);
 
         if (! ($asnObject instanceof Sequence) || $asnObject->getNumberofChildren() !== 4) {
             throw new \RuntimeException('Invalid data.');

--- a/src/Serializer/PublicKey/Der/Parser.php
+++ b/src/Serializer/PublicKey/Der/Parser.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Serializer\PublicKey\Der;
 
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use FG\ASN1\Universal\Sequence;
 use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
 use Mdanter\Ecc\Math\GmpMathInterface;
@@ -45,7 +45,7 @@ class Parser
      */
     public function parse(string $binaryData): PublicKeyInterface
     {
-        $asnObject = Object::fromBinary($binaryData);
+        $asnObject = ASNObject::fromBinary($binaryData);
 
         if (! ($asnObject instanceof Sequence) || $asnObject->getNumberofChildren() != 2) {
             throw new \RuntimeException('Invalid data.');

--- a/src/Serializer/Signature/Der/Parser.php
+++ b/src/Serializer/Signature/Der/Parser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Mdanter\Ecc\Serializer\Signature\Der;
 
 use FG\ASN1\Identifier;
-use FG\ASN1\Object;
+use FG\ASN1\ASNObject;
 use Mdanter\Ecc\Crypto\Signature\Signature;
 use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
 
@@ -17,7 +17,7 @@ class Parser
      */
     public function parse(string $binary): SignatureInterface
     {
-        $object = Object::fromBinary($binary);
+        $object = ASNObject::fromBinary($binary);
         if ($object->getType() !== Identifier::SEQUENCE) {
             throw new \RuntimeException('Invalid data');
         }


### PR DESCRIPTION
closes #207 (https://github.com/fgrosse/PHPASN1/blob/master/CHANGELOG.md#v200-2017-08)

this should be fully backwards compatible, I don't think anything else uses `Object`. However a new release will be needed for projects depending on this lib.