### PR TITLE
Constant size for field element masking in conditional swap

### DIFF
--- a/src/Primitives/Point.php
+++ b/src/Primitives/Point.php
@@ -5,7 +5,6 @@ namespace Mdanter\Ecc\Primitives;
 
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Math\ModularArithmetic;
-use Mdanter\Ecc\Util\BinaryString;
 
 /**
  * *********************************************************************
@@ -277,12 +276,12 @@ class Point implements PointInterface
         for ($i = 0; $i < $k; $i++) {
             $j = $n[$i];
 
-            $this->cswap($r[0], $r[1], $j ^ 1);
+            $this->cswap($r[0], $r[1], $j ^ 1, $k);
 
             $r[0] = $r[0]->add($r[1]);
             $r[1] = $r[1]->getDouble();
 
-            $this->cswap($r[0], $r[1], $j ^ 1);
+            $this->cswap($r[0], $r[1], $j ^ 1, $k);
         }
 
         $r[0]->validate();
@@ -294,29 +293,30 @@ class Point implements PointInterface
      * @param Point $a
      * @param Point $b
      * @param int $cond
+     * @param int $curveSize
      */
-    private function cswap(self $a, self $b, int $cond)
+    private function cswap(self $a, self $b, int $cond, int $curveSize)
     {
-        $this->cswapValue($a->x, $b->x, $cond);
-        $this->cswapValue($a->y, $b->y, $cond);
-        $this->cswapValue($a->order, $b->order, $cond);
-        $this->cswapValue($a->infinity, $b->infinity, $cond);
+        $this->cswapValue($a->x, $b->x, $cond, $curveSize);
+        $this->cswapValue($a->y, $b->y, $cond, $curveSize);
+        $this->cswapValue($a->order, $b->order, $cond, $curveSize);
+        $this->cswapValue($a->infinity, $b->infinity, $cond, 8);
     }
 
     /**
      * @param bool|\GMP $a
      * @param bool|\GMP $b
      * @param int $cond
+     * @param int $maskBitSize
      */
-    public function cswapValue(& $a, & $b, int $cond)
+    public function cswapValue(& $a, & $b, int $cond, int $maskBitSize)
     {
         $isGMP = is_object($a) && $a instanceof \GMP;
 
         $sa = $isGMP ? $a : gmp_init(intval($a), 10);
         $sb = $isGMP ? $b : gmp_init(intval($b), 10);
-        $size = max(BinaryString::length(gmp_strval($sa, 2)), BinaryString::length(gmp_strval($sb, 2)));
 
-        $mask = str_pad('', $size, (string) (1 - intval($cond)), STR_PAD_LEFT);
+        $mask = str_pad('', $maskBitSize, (string) (1 - intval($cond)), STR_PAD_LEFT);
         $mask = gmp_init($mask, 2);
 
         $taA = $this->adapter->bitwiseAnd($sa, $mask);

--- a/tests/unit/Curves/SpecBasedCurveTest.php
+++ b/tests/unit/Curves/SpecBasedCurveTest.php
@@ -55,7 +55,7 @@ class SpecBasedCurveTest extends AbstractTestCase
     {
         if (!isset($this->fileCache[$fileName])) {
             if (!file_exists($fileName)) {
-                throw new \PHPUnit_Runner_Exception("Test fixture file {$fileName} does not exist");
+                throw new \RuntimeException("Test fixture file {$fileName} does not exist");
             }
 
             $this->fileCache[$fileName] = $yaml->parse(file_get_contents($fileName));
@@ -161,6 +161,21 @@ TEXT
 
         $this->assertEquals($adapter->hexDec($expectedX), $adapter->toString($publicKey->getPoint()->getX()), $name);
         $this->assertEquals($adapter->hexDec($expectedY), $adapter->toString($publicKey->getPoint()->getY()), $name);
+    }
+
+    /**
+     * @dataProvider getKeypairsTestSet()
+     * @param string $name
+     * @param GeneratorPoint $generator
+     * @param string $k - decimal private key
+     * @param $expectedX
+     * @param $expectedY
+     */
+    public function testKeyCompression($name, GeneratorPoint $generator, $k, $expectedX, $expectedY)
+    {
+        $adapter = $generator->getAdapter();
+
+        $publicKey = $generator->getPublicKeyFrom(gmp_init($expectedX, 16), gmp_init($expectedY, 16), $generator->getOrder());
 
         $serializer = new UncompressedPointSerializer();
         $serialized = $serializer->serialize($publicKey->getPoint());
@@ -172,7 +187,6 @@ TEXT
         $parsed = $compressingSerializer->unserialize($generator->getCurve(), $serialized);
         $this->assertTrue($parsed->equals($publicKey->getPoint()));
     }
-
 
     /**
      * @return array

--- a/tests/unit/Primitives/PointTest.php
+++ b/tests/unit/Primitives/PointTest.php
@@ -128,22 +128,22 @@ class PointTest extends AbstractTestCase
         $b = $ab;
 
         $adapter = new GmpMath();
-        $parameters = new CurveParameters(32, gmp_init(23, 10), gmp_init(1, 10), gmp_init(1, 10));
+        $parameters = new CurveParameters(67, gmp_init(23, 10), gmp_init(1, 10), gmp_init(1, 10));
         $curve = new CurveFp($parameters, $adapter);
 
         $point = $curve->getPoint(gmp_init(13, 10), gmp_init(7, 10), gmp_init(7, 10));
 
-        $point->cswapValue($a, $b, (int) false);
+        $point->cswapValue($a, $b, (int) false, $curve->getSize());
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($a));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($b));
 
-        $point->cswapValue($a, $b, (int) true);
+        $point->cswapValue($a, $b, (int) true, $curve->getSize());
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($b));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($a));
 
-        $point->cswapValue($a, $b, (int) false);
+        $point->cswapValue($a, $b, (int) false, $curve->getSize());
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($b));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($a));


### PR DESCRIPTION
In the conditional swap algorithm, the values A and B
are swapped using a mask whose length is derived from
the bitsize of A or B (taking the largest)

This costs 8 `gmp_strval` AND `BinaryString::length`
operations per run of `Point::cswap`, so 16 per
iteration of the scalar multiplication loop.

The point values X/Y/order (bigints) are swapped,
along with isInfinity (a boolean). The mask for
isInfinity does not depend on the field size, however
X/Y/order have variable size.

This PR makes use of CurveParameters `size` value as
the mask size to avoid excessive string operations on
the values being swapped.

PointTest::testConditionalSwap yielded invalid results
with the change (without modifying the test). Its
unclear where the value of 32 for the size originated.
The test of cswap was a pure test, uncoupled with
the Point's values. It was updated to 67, the max bit
size of the two to get the test to pass.

Overall this change comes with some performance
improvements. With the point compression test from
`SpecBasedCurveTest::testGetPublicKey` separated out
so scalar multiplication was the dominant factor, the
test completed 14% faster with the change.

    Runs: 32
    A - using curve size
    AverageA: 8.5350606068969s
    TotalA: 273.1219394207s

    B - using existing method
    AverageB: 9.885170340538s
    TotalB: 316.32545089722s

    After 32 runs A is faster by 43.203511476517s
    A on average is faster by 1.3501097336411s seconds
    Time of A with respect to B: 86.342069108263%