### PR TITLE
[Backport 0.4] Constant size for mask in conditional swap

### DIFF
--- a/tests/unit/Curves/SpecBasedCurveTest.php
+++ b/tests/unit/Curves/SpecBasedCurveTest.php
@@ -52,7 +52,7 @@ class SpecBasedCurveTest extends AbstractTestCase
     {
         if (!isset($this->fileCache[$fileName])) {
             if (!file_exists($fileName)) {
-                throw new \PHPUnit_Runner_Exception("Test fixture file {$fileName} does not exist");
+                throw new \RuntimeException("Test fixture file {$fileName} does not exist");
             }
 
             $this->fileCache[$fileName] = $yaml->parse(file_get_contents($fileName));
@@ -158,6 +158,21 @@ TEXT
 
         $this->assertEquals($adapter->hexDec($expectedX), $adapter->toString($publicKey->getPoint()->getX()), $name);
         $this->assertEquals($adapter->hexDec($expectedY), $adapter->toString($publicKey->getPoint()->getY()), $name);
+    }
+
+    /**
+     * @dataProvider getKeypairsTestSet()
+     * @param string $name
+     * @param GeneratorPoint $generator
+     * @param string $k - decimal private key
+     * @param $expectedX
+     * @param $expectedY
+     */
+    public function testKeyCompression($name, GeneratorPoint $generator, $k, $expectedX, $expectedY)
+    {
+        $adapter = $generator->getAdapter();
+
+        $publicKey = $generator->getPublicKeyFrom(gmp_init($expectedX, 16), gmp_init($expectedY, 16), $generator->getOrder());
 
         $serializer = new UncompressedPointSerializer($adapter);
         $serialized = $serializer->serialize($publicKey->getPoint());
@@ -169,7 +184,6 @@ TEXT
         $parsed = $compressingSerializer->unserialize($generator->getCurve(), $serialized);
         $this->assertTrue($parsed->equals($publicKey->getPoint()));
     }
-
 
     /**
      * @return array

--- a/tests/unit/Primitives/PointTest.php
+++ b/tests/unit/Primitives/PointTest.php
@@ -128,22 +128,22 @@ class PointTest extends AbstractTestCase
         $b = $ab;
 
         $adapter = new GmpMath();
-        $parameters = new CurveParameters(32, gmp_init(23, 10), gmp_init(1, 10), gmp_init(1, 10));
+        $parameters = new CurveParameters(67, gmp_init(23, 10), gmp_init(1, 10), gmp_init(1, 10));
         $curve = new CurveFp($parameters, $adapter);
 
         $point = $curve->getPoint(gmp_init(13, 10), gmp_init(7, 10), gmp_init(7, 10));
 
-        $point->cswapValue($a, $b, false);
+        $point->cswapValue($a, $b, (int) false, $curve->getSize());
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($a));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($b));
 
-        $point->cswapValue($a, $b, true);
+        $point->cswapValue($a, $b, (int) true, $curve->getSize());
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($b));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($a));
 
-        $point->cswapValue($a, $b, false);
+        $point->cswapValue($a, $b, (int) false, $curve->getSize());
 
         $this->assertEquals($adapter->toString($aa), $adapter->toString($b));
         $this->assertEquals($adapter->toString($ab), $adapter->toString($a));


### PR DESCRIPTION
In the conditional swap algorithm, the values A and B
are swapped using a mask whose length is derived from
the bitsize of A or B (taking the largest)

This costs 8 `gmp_strval` AND `BinaryString::length`
operations per run of `Point::cswap`, so 16 per
iteration of the scalar multiplication loop.

The point values X/Y/order (bigints) are swapped,
along with isInfinity (a boolean). The mask for
isInfinity does not depend on the field size, however
X/Y/order have variable size.

This PR makes use of CurveParameters `size` value as
the mask size to avoid excessive string operations on
the values being swapped.

PointTest::testConditionalSwap yielded invalid results
with the change (without modifying the test). Its
unclear where the value of 32 for the size originated.
The test of cswap was a pure test, uncoupled with
the Point's values. It was updated to 67, the max bit
size of the two to get the test to pass.

Overall this change comes with some performance
improvements. With the point compression test from
`SpecBasedCurveTest::testGetPublicKey` separated out
so scalar multiplication was the dominant factor, the
test completed 14% faster with the change.

Additional note for v0.4 branch:
The maskBitSize parameter is optional, with the old
remaining in case the default of null is passed, to
retain backwards compatibility with the public facing
API.

    Runs: 4
    AverageA: 8.1569769382477
    TotalA: 32.627907752991

    AverageB: 9.5001559853554
    TotalB: 38.000623941422
    After 4 runs A is faster by 5.3727161884308 
    A on average is faster by 1.3431790471077 seconds
    Time of A with respect to B: 85.86150533551%
