### PR TITLE
[0.4] GeneratorPoint::getPublicKeyFrom - remove unused param 

### DIFF
--- a/src/Primitives/GeneratorPoint.php
+++ b/src/Primitives/GeneratorPoint.php
@@ -85,12 +85,11 @@ class GeneratorPoint extends Point
     /**
      * @param \GMP $x
      * @param \GMP $y
-     * @param \GMP $order
      * @return PublicKey
      */
-    public function getPublicKeyFrom(\GMP $x, \GMP $y, \GMP $order = null)
+    public function getPublicKeyFrom(\GMP $x, \GMP $y)
     {
-        $pubPoint = $this->getCurve()->getPoint($x, $y, $order);
+        $pubPoint = $this->getCurve()->getPoint($x, $y, $this->getOrder());
         return new PublicKey($this->getAdapter(), $this, $pubPoint);
     }
 


### PR DESCRIPTION
Since the field isn't required, not one usage of this
function actually passed the order, despite it already
being available on the generator.

This PR removes the optional parameter, and passes the
order of the generator into getPoint