### PR TITLE
GeneratorPoint::getPublicKeyFrom() - remove unused parameter

### DIFF
--- a/src/Primitives/GeneratorPoint.php
+++ b/src/Primitives/GeneratorPoint.php
@@ -88,12 +88,11 @@ class GeneratorPoint extends Point
     /**
      * @param \GMP $x
      * @param \GMP $y
-     * @param \GMP $order
      * @return PublicKeyInterface
      */
-    public function getPublicKeyFrom(\GMP $x, \GMP $y, \GMP $order = null): PublicKeyInterface
+    public function getPublicKeyFrom(\GMP $x, \GMP $y): PublicKeyInterface
     {
-        $pubPoint = $this->getCurve()->getPoint($x, $y, $order);
+        $pubPoint = $this->getCurve()->getPoint($x, $y, $this->getOrder());
         return new PublicKey($this->getAdapter(), $this, $pubPoint);
     }
 


### PR DESCRIPTION
Since the field isn't required, not one usage of this
function actually passed the order, despite it already
being available on the generator.

This PR removes the optional parameter, and passes the
order of the generator into getPoint