### PR TITLE
export ignore doc/examples/tests in distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/doc                export-ignore
+/examples           export-ignore
+/tests              export-ignore


### PR DESCRIPTION
would be great if we wouldn't get the examples and tests via composer, when installing with --prefer-dist.

for background see https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/