### PR TITLE
GmpMath - remove string type from baseConvert value

### DIFF
--- a/src/Math/DebugDecorator.php
+++ b/src/Math/DebugDecorator.php
@@ -546,7 +546,7 @@ class DebugDecorator implements GmpMathInterface
      * {@inheritDoc}
      * @see \Mdanter\Ecc\Math\GmpMathInterface::baseConvert()
      */
-    public function baseConvert(string $value, int $fromBase, int $toBase): string
+    public function baseConvert($value, int $fromBase, int $toBase): string
     {
         $func = __METHOD__;
         $args = func_get_args();

--- a/src/Math/GmpMath.php
+++ b/src/Math/GmpMath.php
@@ -308,7 +308,7 @@ class GmpMath implements GmpMathInterface
      * {@inheritDoc}
      * @see GmpMathInterface::baseConvert()
      */
-    public function baseConvert(string $number, int $from, int $to): string
+    public function baseConvert($number, int $from, int $to): string
     {
         return gmp_strval(gmp_init($number, $from), $to);
     }

--- a/src/Math/GmpMathInterface.php
+++ b/src/Math/GmpMathInterface.php
@@ -212,7 +212,7 @@ interface GmpMathInterface
      * @param int $toBase
      * @return string
      */
-    public function baseConvert(string $value, int $fromBase, int $toBase): string;
+    public function baseConvert($value, int $fromBase, int $toBase): string;
 
     /**
      * @return NumberTheory


### PR DESCRIPTION
This prevents us from passing in scalar ints..