### PR TITLE
0.3 - Support PHP v. >= 7.2.0: use 'random_bytes' when available

### DIFF
--- a/src/Random/RandomBytesGenerator.php
+++ b/src/Random/RandomBytesGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Mdanter\Ecc\Random;
+
+use Mdanter\Ecc\Math\MathAdapterInterface;
+use Mdanter\Ecc\Util\NumberSize;
+
+class RandomBytesGenerator implements RandomNumberGeneratorInterface
+{
+    /**
+     * @var MathAdapterInterface
+     */
+    private $adapter;
+    
+    /**
+     * @param MathAdapterInterface $adapter
+     */
+     
+    public function __construct(MathAdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+    
+    /**
+     * @param int|string $max
+     * @return int|string
+     */
+    public function generate($max)
+    {
+        $bytes = NumberSize::getFlooredByteSize($this->adapter, $max);
+        $random = random_bytes($bytes);
+        return $this->adapter->hexDec(bin2hex($random));
+    }
+}

--- a/src/Random/RandomGeneratorFactory.php
+++ b/src/Random/RandomGeneratorFactory.php
@@ -30,6 +30,10 @@ class RandomGeneratorFactory
         if (self::$forcedGenerator !== null) {
             return self::$forcedGenerator;
         }
+        
+        if (function_exists('random_bytes')) {
+            return self::getRandomBytesGenerator($debug);
+        }
 
         if (extension_loaded('mcrypt')) {
             return self::getUrandomGenerator($debug);
@@ -41,6 +45,19 @@ class RandomGeneratorFactory
 
         throw new \RuntimeException('No usable RandomGenerator was found');
     }
+    
+    /**
+     * @param bool $debug
+     * @return DebugDecorator|RandomNumberGeneratorInterface
+     */
+    public static function getRandomBytesGenerator($debug = false)
+    {
+        return self::wrapAdapter(
+            new RandomBytesGenerator(MathAdapterFactory::getAdapter($debug)),
+            'random_bytes',
+            $debug
+        );
+    }  
 
     /**
      * @param bool $debug


### PR DESCRIPTION
In branch 0.3,` RandomGeneratorFactory::getRandomGenerator` returns `URandomGenerator` which uses `mcrypt_create_iv`, DEPRECATED in PHP 7.1.0, and REMOVED in PHP 7.2.0.
So to force compatibility with PHP >= 7.2.0:

1. created new class `RandomBytesGenerator`
2. added new method `RandomGeneratorFactory::getRandomBytesGenerator`
3. edited `RandomGeneratorFactory::getRandomGenerator` to return `RandomGeneratorFactory::getRandomBytesGenerator` when `random_bytes` function is defined.
