### PR TITLE
0.3: add very simple test for two random number generator classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.1",
         "squizlabs/php_codesniffer": "~2",
-        "symfony/yaml": "~2.6"
+        "symfony/yaml": "~2.6",
+        "paragonie/random_compat": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/unit/Random/RandomBytesGeneratorTest.php
+++ b/tests/unit/Random/RandomBytesGeneratorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Random;
+
+
+use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Random\RandomBytesGenerator;
+
+class RandomBytesGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGeneratesData()
+    {
+        $this->assertTrue(function_exists('random_bytes'));
+
+        $bits = 16;
+        $bits16 = pow(2, $bits)-1;
+        $math = new Gmp();
+        $rng = new RandomBytesGenerator($math);
+        $hex = $math->decHex($rng->generate($bits16));
+        $this->assertEquals(4, strlen($hex));
+    }
+}

--- a/tests/unit/Random/URandomNumberGeneratorTest.php
+++ b/tests/unit/Random/URandomNumberGeneratorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mdanter\Ecc\Tests\Random;
+
+
+use Mdanter\Ecc\Math\Gmp;
+use Mdanter\Ecc\Random\URandomNumberGenerator;
+
+class URandomNumberGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGeneratesData()
+    {
+        $bits = 16;
+        $bits16 = pow(2, $bits)-1;
+        $math = new Gmp();
+        $rng = new URandomNumberGenerator($math);
+        $hex = $math->decHex($rng->generate($bits16));
+        $this->assertEquals(4, strlen($hex));
+    }
+}


### PR DESCRIPTION
Adds a small test case checking that the classes
return something for the mcrypt and random_bytes
implementations.

The tests can technically fail, because decHex
won't pad the result16 bits, and there's a chance
that one byte would be 0x00, resulting in single
byte of output. It's unlikely, but we don't
generate that many test runs on 0.3