### PR TITLE
HmacRandomNumberGenerator: Fix hash length for sha384

### DIFF
--- a/src/Random/HmacRandomNumberGenerator.php
+++ b/src/Random/HmacRandomNumberGenerator.php
@@ -37,7 +37,7 @@ class HmacRandomNumberGenerator implements RandomNumberGeneratorInterface
         'sha1' => 160,
         'sha224' => 224,
         'sha256' => 256,
-        'sha384' => 385,
+        'sha384' => 384,
         'sha512' => 512
     );
 


### PR DESCRIPTION
Fixes https://github.com/phpecc/phpecc/issues/226