### PR TITLE
composer: require fgrosse/phpasn1 ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.0",
         "ext-gmp": "*",
-        "fgrosse/phpasn1": "v2.0.x"
+        "fgrosse/phpasn1": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
-        "squizlabs/php_codesniffer": "~2",
-        "symfony/yaml": "~2.6|~3.0"
+        "squizlabs/php_codesniffer": "^2.0",
+        "symfony/yaml": "^2.6|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Update to a newer version and use a different require pattern. Tests are passing.

Changelogs summary:

 - fgrosse/phpasn1 updated from 2.0.1 to 2.1.0
   See changes: https://github.com/fgrosse/PHPASN1/compare/2.0.1...2.1.0
   Release notes: https://github.com/fgrosse/PHPASN1/releases/tag/2.1.0