### PR TITLE
Backport 0.4: Fix signature verification off by one error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
+    - hhvm-3.18
 
 dist: trusty 
 

--- a/src/Crypto/Signature/Signer.php
+++ b/src/Crypto/Signature/Signer.php
@@ -108,11 +108,11 @@ class Signer
 
         $math = $this->adapter;
         $one = gmp_init(1, 10);
-        if ($math->cmp($r, $one) < 1 || $math->cmp($r, $math->sub($n, $one)) > 0) {
+        if ($math->cmp($r, $one) < 0 || $math->cmp($r, $math->sub($n, $one)) > 0) {
             return false;
         }
 
-        if ($math->cmp($s, $one) < 1 || $math->cmp($s, $math->sub($n, $one)) > 0) {
+        if ($math->cmp($s, $one) < 0 || $math->cmp($s, $math->sub($n, $one)) > 0) {
             return false;
         }
 


### PR DESCRIPTION
valid range is [1,n-1], had [2,n-1]. Backported from #254 