### PR TITLE
Use symfony 5 component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^2.0",
-        "symfony/yaml": "^2.6|^3.0"
+        "symfony/yaml": "^3.0|^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi, updated composer.json to allow symfony 5 yaml component. Also, removed 2.6 from requirements because project requires php 7, so it's safe to use version from 3.0.

#SymfonyHackday