### PR TITLE
Add support IEEE-P1363 signature format

### DIFF
--- a/src/Serializer/Signature/IEEEP1363/Formatter.php
+++ b/src/Serializer/Signature/IEEEP1363/Formatter.php
@@ -8,13 +8,19 @@ class Formatter
 {
     /**
      * @param SignatureInterface $signature
+     * @param int $curveSize
      * @return string
      */
-    public function serialize(SignatureInterface $signature): string
+    public function serialize(SignatureInterface $signature, int $curveSize = 0): string
     {
         $r = gmp_strval($signature->getR(), 16);
         $s = gmp_strval($signature->getS(), 16);
-        $len = max(strlen($r), strlen($s));
+        if ($curveSize) {
+            $len = (($curveSize + 7) >> 3) << 1;
+        } else {
+            // Attempt to determine this from $r and $s
+            $len = max(strlen($r), strlen($s));
+        }
         return hex2bin(
             str_pad($r, $len, '0', STR_PAD_LEFT) .
             str_pad($s, $len, '0', STR_PAD_LEFT)

--- a/src/Serializer/Signature/IEEEP1363/Formatter.php
+++ b/src/Serializer/Signature/IEEEP1363/Formatter.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Serializer\Signature\IEEEP1363;
+
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+class Formatter
+{
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature): string
+    {
+        $r = gmp_strval($signature->getR(), 16);
+        $s = gmp_strval($signature->getS(), 16);
+        $len = max(strlen($r), strlen($s));
+        return hex2bin(
+            str_pad($r, $len, '0', STR_PAD_LEFT) .
+            str_pad($s, $len, '0', STR_PAD_LEFT)
+        );
+    }
+}

--- a/src/Serializer/Signature/IEEEP1363/Formatter.php
+++ b/src/Serializer/Signature/IEEEP1363/Formatter.php
@@ -16,6 +16,7 @@ class Formatter
         $r = gmp_strval($signature->getR(), 16);
         $s = gmp_strval($signature->getS(), 16);
         if ($curveSize) {
+            // Round up to nearest byte size, then double (for hex)
             $len = (($curveSize + 7) >> 3) << 1;
         } else {
             // Attempt to determine this from $r and $s

--- a/src/Serializer/Signature/IEEEP1363/Parser.php
+++ b/src/Serializer/Signature/IEEEP1363/Parser.php
@@ -1,0 +1,34 @@
+<?php
+namespace Mdanter\Ecc\Serializer\Signature\IEEEP1363;
+
+use Mdanter\Ecc\Crypto\Signature\Signature;
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+use Mdanter\Ecc\Exception\SignatureDecodeException;
+use Mdanter\Ecc\Util\BinaryString;
+
+/**
+ * Class Parser
+ * @package Mdanter\Ecc\Serializer\Signature\IEEEP1363
+ */
+class Parser
+{
+    /**
+     * @param string $binary
+     * @return SignatureInterface
+     */
+    public function parse(string $binary): SignatureInterface
+    {
+        $total_length = BinaryString::length($binary);
+        if (($total_length & 1) !== 0) {
+            throw new SignatureDecodeException('IEEE-P1363 signatures must be an even length');
+        }
+        $piece_len = $total_length >> 1;
+        $r = bin2hex(BinaryString::substring($binary, 0, $piece_len));
+        $s = bin2hex(BinaryString::substring($binary, $piece_len, $piece_len));
+
+        return new Signature(
+            gmp_init($r, 16),
+            gmp_init($s, 16)
+        );
+    }
+}

--- a/src/Serializer/Signature/IEEEP1363Serializer.php
+++ b/src/Serializer/Signature/IEEEP1363Serializer.php
@@ -2,6 +2,7 @@
 namespace Mdanter\Ecc\Serializer\Signature;
 
 use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+use Mdanter\Ecc\Primitives\CurveFp;
 
 /**
  * Class IEEEP1363Serializer
@@ -19,19 +20,29 @@ class IEEEP1363Serializer implements IEEEP1363SerializerInterface
      */
     private $formatter;
 
-    public function __construct()
+    /**
+     * @var CurveFp
+     */
+    private $curveFp;
+
+    public function __construct(CurveFp $curveFp = null)
     {
         $this->parser = new IEEEP1363\Parser();
         $this->formatter = new IEEEP1363\Formatter();
+        $this->curveFp = $curveFp;
     }
     
     /**
      * @param SignatureInterface $signature
+     * @param int $curveSize Expected bit length of the R and S
      * @return string
      */
-    public function serialize(SignatureInterface $signature): string
+    public function serialize(SignatureInterface $signature, int $curveSize = 0): string
     {
-        return $this->formatter->serialize($signature);
+        if ($this->curveFp && !$curveSize) {
+            $curveSize = $this->curveFp->getSize();
+        }
+        return $this->formatter->serialize($signature, $curveSize);
     }
 
     /**

--- a/src/Serializer/Signature/IEEEP1363Serializer.php
+++ b/src/Serializer/Signature/IEEEP1363Serializer.php
@@ -1,0 +1,45 @@
+<?php
+namespace Mdanter\Ecc\Serializer\Signature;
+
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+/**
+ * Class IEEEP1363Serializer
+ * @package Mdanter\Ecc\Serializer\Signature
+ */
+class IEEEP1363Serializer implements IEEEP1363SerializerInterface
+{
+    /**
+     * @var IEEEP1363\Parser
+     */
+    private $parser;
+
+    /**
+     * @var IEEEP1363\Formatter
+     */
+    private $formatter;
+
+    public function __construct()
+    {
+        $this->parser = new IEEEP1363\Parser();
+        $this->formatter = new IEEEP1363\Formatter();
+    }
+    
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature): string
+    {
+        return $this->formatter->serialize($signature);
+    }
+
+    /**
+     * @param string $binary
+     * @return SignatureInterface
+     */
+    public function parse(string $binary): SignatureInterface
+    {
+        return $this->parser->parse($binary);
+    }
+}

--- a/src/Serializer/Signature/IEEEP1363SerializerInterface.php
+++ b/src/Serializer/Signature/IEEEP1363SerializerInterface.php
@@ -1,0 +1,23 @@
+<?php
+namespace Mdanter\Ecc\Serializer\Signature;
+
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+/**
+ * Interface IEEEP1363SerializerInterface
+ * @package Mdanter\Ecc\Serializer\Signature
+ */
+interface IEEEP1363SerializerInterface
+{
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature): string;
+
+    /**
+     * @param string $binary
+     * @return SignatureInterface
+     */
+    public function parse(string $binary): SignatureInterface;
+}

--- a/tests/unit/Serializer/Signature/IEEEP1363SerializerTest.php
+++ b/tests/unit/Serializer/Signature/IEEEP1363SerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Mdanter\Ecc\Tests\Serializer\Signature;
 
 use Mdanter\Ecc\Crypto\Signature\Signature;
+use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Math\GmpMath;
 use Mdanter\Ecc\Random\RandomGeneratorFactory;
 use Mdanter\Ecc\Serializer\Signature\IEEEP1363Serializer;
@@ -18,7 +19,7 @@ class IEEEP1363SerializerTest extends AbstractTestCase
         $expected = '2130e7d504c4a498c3b3c7c0fed6de2a84811a3bd89badb8627658f2b1ea5029' .
             '48cb1410308e3efc512b4ce0974f6d0869e9454095c8855abea6b6325a40d0a7';
         $signature = new Signature($r, $s);
-        $serializer = new IEEEP1363Serializer();
+        $serializer = new IEEEP1363Serializer((new NistCurve(new GmpMath()))->curve256());
         $serialized = bin2hex($serializer->serialize($signature));
         $this->assertEquals($expected, $serialized);
     }
@@ -36,6 +37,13 @@ class IEEEP1363SerializerTest extends AbstractTestCase
         $signature = new Signature($r, $s);
 
         $serialized = $serializer->serialize($signature);
+        $parsed = $serializer->parse($serialized);
+
+        $this->assertTrue($math->equals($signature->getR(), $parsed->getR()));
+        $this->assertTrue($math->equals($signature->getS(), $parsed->getS()));
+
+        // Let's test with an explicit size:
+        $serialized = $serializer->serialize($signature, 384);
         $parsed = $serializer->parse($serialized);
 
         $this->assertTrue($math->equals($signature->getR(), $parsed->getR()));

--- a/tests/unit/Serializer/Signature/IEEEP1363SerializerTest.php
+++ b/tests/unit/Serializer/Signature/IEEEP1363SerializerTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Mdanter\Ecc\Tests\Serializer\Signature;
+
+use Mdanter\Ecc\Crypto\Signature\Signature;
+use Mdanter\Ecc\Math\GmpMath;
+use Mdanter\Ecc\Random\RandomGeneratorFactory;
+use Mdanter\Ecc\Serializer\Signature\IEEEP1363Serializer;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class IEEEP1363SerializerTest extends AbstractTestCase
+{
+    public function testParsesSignature()
+    {
+        $r = gmp_init('15012732708734045374201164973195778115424038544478436215140305923518805725225', 10);
+        $s = gmp_init('32925333523544781093325025052915296870609904100588287156912210086353851961511', 10);
+        $expected = '2130e7d504c4a498c3b3c7c0fed6de2a84811a3bd89badb8627658f2b1ea5029' .
+            '48cb1410308e3efc512b4ce0974f6d0869e9454095c8855abea6b6325a40d0a7';
+        $signature = new Signature($r, $s);
+        $serializer = new IEEEP1363Serializer();
+        $serialized = bin2hex($serializer->serialize($signature));
+        $this->assertEquals($expected, $serialized);
+    }
+
+    public function testIsConsistent()
+    {
+        $math = new GmpMath();
+        $rbg = RandomGeneratorFactory::getRandomGenerator();
+        $serializer = new IEEEP1363Serializer();
+
+        $i = 256;
+        $max = $math->sub($math->pow(gmp_init(2, 10), $i), gmp_init(1, 10));
+        $r = $rbg->generate($max);
+        $s = $rbg->generate($max);
+        $signature = new Signature($r, $s);
+
+        $serialized = $serializer->serialize($signature);
+        $parsed = $serializer->parse($serialized);
+
+        $this->assertTrue($math->equals($signature->getR(), $parsed->getR()));
+        $this->assertTrue($math->equals($signature->getS(), $parsed->getS()));
+    }
+}


### PR DESCRIPTION
IEEE-P1363 signatures (r, s) are encoded simply as r || s (where || means "concatenate").

If this isn't desired, we're already working around this in our wrapper library, so no big deal. https://github.com/paragonie/easy-ecc/pull/3