### PR TITLE
Constant-Time Arithmetic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
 
   coverage:
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
     strategy:
       matrix:
         operating-system: ['ubuntu-20.04']

--- a/src/Math/ConstantTimeMath.php
+++ b/src/Math/ConstantTimeMath.php
@@ -1,0 +1,202 @@
+<?php
+declare(strict_types=1);
+
+namespace Mdanter\Ecc\Math;
+
+use GMP;
+use Mdanter\Ecc\Exception\NumberTheoryException;
+use Mdanter\Ecc\Util\BinaryString;
+
+/**
+ * Class ConstantTimeMath
+ *
+ * This class extends GmpMath to replace some GMP functions with algorithms
+ * guaranteed to be constant-time.
+ *
+ * @package Mdanter\Ecc\Math
+ */
+class ConstantTimeMath extends GmpMath
+{
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::inverseMod()
+     */
+    public function inverseMod(GMP $a, GMP $m): GMP
+    {
+        list($x, $y) = $this->binaryGcd($a, $m);
+        if (!$this->equals($y, \gmp_init(1))) {
+            throw new NumberTheoryException('No inverse exists for these two numbers');
+        }
+
+        return $x;
+    }
+
+    /**
+     * Stein's Algorithm (Binary GCD)
+     *
+     * Based on algorithm 14.61 from the Handbook of Applied Cryptography
+     *
+     * @param GMP $X
+     * @param GMP $Y
+     * @return GMP[] ($gcd, $inverse)
+     */
+    public function binaryGcd(GMP $X, GMP $Y): array
+    {
+        // Don't mutate the input parameters
+        $x = clone $X;
+        $y = clone $Y;
+        $g = \min($this->trailingZeroes($x), $this->trailingZeroes($y));
+        $x = $this->rightShift($x, $g);
+        $x = $this->rightShift($x, $g);
+        $u = clone $x;
+        $v = clone $y;
+
+        $zero = \gmp_init(0, 10);
+        $a = \gmp_init(1, 10);
+        $b = \gmp_init(0, 10);
+        $c = \gmp_init(0, 10);
+        $d = \gmp_init(1, 10);
+
+        do {
+            for ($bits = $this->trailingZeroes($u); $bits > 0; --$bits) {
+                $u = $this->rightShift($u, 1);
+                $swap = (~$this->lsb($a) & ~$this->lsb($b)) & 1;
+
+                $a = $this->select($swap, $a, $this->add($a, $y));
+                $a = $this->rightShift($a, 1);
+
+                $b = $this->select($swap, $b, $this->sub($b, $x));
+                $b = $this->rightShift($b, 1);
+            }
+
+            for ($bits = $this->trailingZeroes($v); $bits > 0; --$bits) {
+                $v = $this->rightShift($v, 1);
+                $swap = (~$this->lsb($c) & ~$this->lsb($d)) & 1;
+
+                $c = $this->select($swap, $c, $this->add($c, $y));
+                $c = $this->rightShift($c, 1);
+
+                $d = $this->select($swap, $d, $this->sub($d, $x));
+                $d = $this->rightShift($d, 1);
+            }
+
+            $cmp = $this->cmp($u, $v);
+            /*
+             | cmp(u, v) | swap |
+             +---------------+------+
+             | -1            |    0 |
+             |  0            |    1 |
+             |  1            |    1 |
+             */
+            // if ($u >= $v):
+            $swap = 1 - (($cmp >> 1) & 1);
+
+            // swap = (1 - (compare_alt(u, v)[0] >>> 31));
+            $u = $this->select($swap, $this->sub($u, $v), $u);
+            $a = $this->select($swap, $this->sub($a, $c), $a);
+            $b = $this->select($swap, $this->sub($b, $d), $b);
+
+            $swap = 1 - $swap;
+            // else:
+            $v = $this->select($swap, $this->sub($v, $u), $v);
+            $c = $this->select($swap, $this->sub($c, $a), $c);
+            $d = $this->select($swap, $this->sub($d, $b), $d);
+        } while (!$this->equals($u, $zero));
+
+        return [$c, $this->leftShift($v, $g)];
+    }
+
+    /**
+     * Constant-time conditional select.
+     *
+     * returns ($bit === 1 ? $a : $b)
+     *
+     * @param int $bit
+     * @param GMP $a
+     * @param GMP $b
+     * @return GMP
+     */
+    public function select(int $bit, GMP $a, GMP $b): GMP
+    {
+        // Handle the sign bits (for multiplying later)
+        $a_sign = gmp_sign($a);
+        $b_sign = gmp_sign($b);
+        /* if bit: sign = a_sign
+         * else: sign = b_sign
+         */
+        $sign = $b_sign ^ (($a_sign ^ $b_sign) & -$bit);
+
+        // ($mask = $bit ? 0xff : 0x00) without branches
+        $mask = -($bit & 1) & 0xff;
+
+        // Work with the positive hex values:
+        $a_hex = gmp_strval(gmp_abs($a), 16);
+        $b_hex = gmp_strval(gmp_abs($b), 16);
+        $length = max(BinaryString::length($a_hex), BinaryString::length($b_hex));
+        $length += $length & 1;
+
+        $left = hex2bin(str_pad($a_hex, $length, '0', STR_PAD_LEFT));
+        $right = hex2bin(str_pad($b_hex, $length, '0', STR_PAD_LEFT));
+        $length >>= 1;
+
+        $out = [];
+        for ($i = 0; $i < $length; ++$i) {
+            $l = $this->ord($left[$i]);
+            $r = $this->ord($right[$i]);
+            $out[$i] = $this->chr($r ^ (($l ^ $r) & $mask));
+        }
+        // Re-multiply the sign bit:
+        return $this->mul(
+            gmp_init(bin2hex(implode('', $out)), 16),
+            gmp_init($sign, 10)
+        );
+    }
+
+    /**
+     * How many trailing zero bits are in this number?
+     *
+     * @param GMP $num
+     * @return int
+     */
+    public function trailingZeroes(GMP $num): int
+    {
+        return \max(
+            0,
+            \gmp_scan1($num, 0)
+        );
+    }
+
+    /**
+     * Get the least significant bit of $num.
+     *
+     * @param GMP $num
+     * @return int
+     */
+    public function lsb(GMP $num): int
+    {
+        return gmp_intval($num) & 1;
+    }
+
+    /**
+     * Get an unsigned integer for the character in the provided string at index 0.
+     *
+     * @param string $chr
+     * @return int
+     */
+    public function ord(string $chr): int
+    {
+        return unpack('C', $chr)[1];
+    }
+
+    /**
+     * Turn an integer in the range [0, 255] into a string character.
+     * Unlike PHP's chr(), this doesn't have a cache-timing leak.
+     *
+     * @param int $c
+     * @return string
+     */
+    public function chr(int $c): string
+    {
+        return pack('C', $c);
+    }
+}

--- a/src/Math/ConstantTimeMath.php
+++ b/src/Math/ConstantTimeMath.php
@@ -181,15 +181,25 @@ class ConstantTimeMath extends GmpMath
     /**
      * How many trailing zero bits are in this number?
      *
+     * We can't just use gmp_scan1() for this, because its runtime
+     * is variable based on the number of trailing 0 bits.
+     *
      * @param GMP $num
      * @return int
      */
     public function trailingZeroes(GMP $num): int
     {
-        return \max(
-            0,
-            \gmp_scan1($num, 0)
-        );
+        $trailing = 0;
+        $b = 0;
+        $found = 0;
+        $strval = gmp_strval($num, 2);
+        for ($i = BinaryString::length($strval) - 1; $i >= 0; --$i) {
+            $bit = $this->ord($strval[$i]) & 1;
+            $trailing = ((-$bit & $b) & ~$found) ^ ($trailing & $found);
+            $found |= -$bit; // -1 if found, 0 if not
+            ++$b;
+        }
+        return $trailing;
     }
 
     /**

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Tests;
 
-use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Math\MathAdapterFactory;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Tests;
 
+use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Math\MathAdapterFactory;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/Math/ConstantTimeMathTest.php
+++ b/tests/unit/Math/ConstantTimeMathTest.php
@@ -7,6 +7,28 @@ use Mdanter\Ecc\Math\ConstantTimeMath;
 
 class ConstantTimeMathTest extends MathTestBase
 {
+    public function testCompareSigns()
+    {
+        $math = new ConstantTimeMath();
+        $required = [
+            [-1, -1, 0, 1],
+            [-1,  0, 0, 0],
+            [-1,  1, 0, 0],
+            [ 0, -1, 1, 0],
+            [ 0,  0, 0, 1],
+            [ 0,  1, 0, 0],
+            [ 1, -1, 1, 0],
+            [ 1,  0, 1, 0],
+            [ 1,  1, 0, 1],
+        ];
+        foreach ($required as $i => $row) {
+            list($first, $other, $gt, $eq) = $row;
+            list($a, $b) = $math->compareSigns($first, $other);
+            $this->assertSame($a, $gt, "gt is wrong on row {$i} ({$first}, {$other}, {$gt}, {$eq})");
+            $this->assertSame($b, $eq, "eq is wrong on row {$i} ({$first}, {$other}, {$gt}, {$eq})");
+        }
+    }
+
     public function testCmp()
     {
         $math = new ConstantTimeMath();
@@ -14,10 +36,28 @@ class ConstantTimeMathTest extends MathTestBase
         $bigger = '7f' . bin2hex(random_bytes(16)) . '7f';
         $a = gmp_init($big, 16);
         $b = gmp_init($bigger, 16);
+        $c = gmp_init('-' . $bigger, 16); // negative
 
         $this->assertEquals(-1, $math->cmp($a, $b), "{$a} < {$b}");
-        $this->assertEquals(0, $math->cmp($a, $a), "{$a} == {$b}");
-        $this->assertEquals(1, $math->cmp($b, $a), "{$a} > {$b}");
+        $this->assertEquals(0, $math->cmp($a, $a), "{$a} == {$a}");
+        $this->assertEquals(0, $math->cmp($b, $b), "{$b} == {$b}");
+        $this->assertEquals(1, $math->cmp($b, $a), "{$b} > {$a}");
+
+        $this->assertEquals(-1, $math->cmp($c, $b), "{$c} < {$b}");
+        $this->assertEquals(0, $math->cmp($b, $b), "{$b} == {$b}");
+        $this->assertEquals(0, $math->cmp($c, $c), "{$c} == {$c}");
+        $this->assertEquals(1, $math->cmp($b, $c), "{$c} > {$b}");
+
+        $d = gmp_init(0, 10);
+        $e = gmp_init(1, 10);
+        $this->assertEquals(-1, $math->cmp($d, $e), "{$d} < {$e}");
+        $this->assertEquals(0, $math->cmp($d, $d), "{$d} == {$d}");
+        $this->assertEquals(0, $math->cmp($e, $e), "{$e} == {$e}");
+        $this->assertEquals(1, $math->cmp($e, $d), "{$e} > {$d}");
+
+        $f = gmp_init('1e0ea4fd44a90d57c67fda8e7b9fb98b5dca575e777d911e6de72dfc8cd02b55', 16);
+        $g = gmp_init('ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551', 16);
+        $this->assertEquals(-1, $math->cmp($f, $g), "{$f} < {$g}");
     }
 
     public function testOrdChr()
@@ -41,6 +81,11 @@ class ConstantTimeMathTest extends MathTestBase
             [gmp_init('fffc', 16), 2],
             [gmp_init('fff8', 16), 3],
             [gmp_init('fff0', 16), 4],
+            [gmp_init('ff00', 16), 8],
+            [gmp_init('f000', 16), 12],
+            [gmp_init('e000', 16), 13],
+            [gmp_init('c000', 16), 14],
+            [gmp_init('8000', 16), 15],
         ];
         foreach ($vectors as $vector) {
             list($in, $expect) = $vector;
@@ -58,12 +103,28 @@ class ConstantTimeMathTest extends MathTestBase
         $even = gmp_init('2345678', 10);
         $this->assertEquals(1, $math->lsb($odd));
         $this->assertEquals(0, $math->lsb($even));
+
+        $odd = gmp_init('-1234567', 10);
+        $even = gmp_init('-2345678', 10);
+        $this->assertEquals(1, $math->lsb($odd));
+        $this->assertEquals(0, $math->lsb($even));
     }
 
     public function testSelect()
     {
         $math = new ConstantTimeMath();
         $left = gmp_init('1234567', 10);
+        $right = gmp_init('7654321', 10);
+        $this->assertEquals(
+            $left,
+            $math->select(1, $left, $right)
+        );
+        $this->assertEquals(
+            $right,
+            $math->select(0, $left, $right)
+        );
+
+        $left = gmp_init('-1234567', 10);
         $right = gmp_init('7654321', 10);
         $this->assertEquals(
             $left,

--- a/tests/unit/Math/ConstantTimeMathTest.php
+++ b/tests/unit/Math/ConstantTimeMathTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Mdanter\Ecc\Tests\Math;
+
+use Mdanter\Ecc\Math\ConstantTimeMath;
+
+class ConstantTimeMathTest extends MathTestBase
+{
+    public function testOrdChr()
+    {
+        $math = new ConstantTimeMath();
+        $byte = random_bytes(1);
+        $ord = $math->ord($byte);
+        $this->assertGreaterThan(-1, $ord);
+        $this->assertLessThan(256, $ord);
+        $chr = $math->chr($ord);
+        $this->assertSame(bin2hex($chr), bin2hex($byte));
+    }
+
+    public function testTrailingZeroes()
+    {
+        $math = new ConstantTimeMath();
+        $vectors = [
+            [gmp_init('0000', 16), 0], // gmp_scan1($x, 0) says -1, we say 0
+            [gmp_init('ffff', 16), 0],
+            [gmp_init('fffe', 16), 1],
+            [gmp_init('fffc', 16), 2],
+            [gmp_init('fff8', 16), 3],
+            [gmp_init('fff0', 16), 4],
+        ];
+        foreach ($vectors as $vector) {
+            list($in, $expect) = $vector;
+            $this->assertEquals(
+                $expect,
+                $math->trailingZeroes($in)
+            );
+        }
+    }
+
+    public function testLsb()
+    {
+        $math = new ConstantTimeMath();
+        $odd = gmp_init('1234567', 10);
+        $even = gmp_init('2345678', 10);
+        $this->assertEquals(1, $math->lsb($odd));
+        $this->assertEquals(0, $math->lsb($even));
+    }
+
+    public function testSelect()
+    {
+        $math = new ConstantTimeMath();
+        $left = gmp_init('1234567', 10);
+        $right = gmp_init('7654321', 10);
+        $this->assertEquals(
+            $left,
+            $math->select(1, $left, $right)
+        );
+        $this->assertEquals(
+            $right,
+            $math->select(0, $left, $right)
+        );
+    }
+}

--- a/tests/unit/Math/ConstantTimeMathTest.php
+++ b/tests/unit/Math/ConstantTimeMathTest.php
@@ -7,6 +7,19 @@ use Mdanter\Ecc\Math\ConstantTimeMath;
 
 class ConstantTimeMathTest extends MathTestBase
 {
+    public function testCmp()
+    {
+        $math = new ConstantTimeMath();
+        $big    = '01' . bin2hex(random_bytes(16)) . '01';
+        $bigger = '7f' . bin2hex(random_bytes(16)) . '7f';
+        $a = gmp_init($big, 16);
+        $b = gmp_init($bigger, 16);
+
+        $this->assertEquals(-1, $math->cmp($a, $b), "{$a} < {$b}");
+        $this->assertEquals(0, $math->cmp($a, $a), "{$a} == {$b}");
+        $this->assertEquals(1, $math->cmp($b, $a), "{$a} > {$b}");
+    }
+
     public function testOrdChr()
     {
         $math = new ConstantTimeMath();

--- a/tests/unit/Math/MathTest.php
+++ b/tests/unit/Math/MathTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Tests\Math;
 
+use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Math\GmpMath;
 use Mdanter\Ecc\Math\GmpMathInterface;
 
@@ -312,5 +313,13 @@ class MathTest extends MathTestBase
         $this->expectExceptionMessage("Number overflows byte size");
 
         $math->intToFixedSizeString($integer, $size);
+    }
+
+
+    public function getAdapters()
+    {
+        return $this->_getAdapters(array(
+            array(new ConstantTimeMath())
+        ));
     }
 }


### PR DESCRIPTION
Implement constant-time math, featuring an inverseMod() implementation suitable for handling private keys.

Fixes #279.

To use this algorithm, pass the `ConstantTimeMath` object to the `Signer` or `Random` constructor.

(Easy-ECC will do this automatically for users when constant-time arithmetic is needed.)

~~There are a few other methods that should also be made constant-time (i.e. `cmp()`), but `modInverse()` is the difficult nut to crack.~~ `cmp()` is now covered too.

https://cacr.uwaterloo.ca/hac/about/chap14.pdf -- page 19 (algorithm 14.61) is what this implemented.