### PR TITLE
Hedged ECDSA Signatures

### DIFF
--- a/src/Random/HedgedRandomNumberGenerator.php
+++ b/src/Random/HedgedRandomNumberGenerator.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Random;
+
+class HedgedRandomNumberGenerator extends HmacRandomNumberGenerator
+{
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    protected function optionalSuffix(): string
+    {
+        return random_bytes(32);
+    }
+}

--- a/src/Random/HmacRandomNumberGenerator.php
+++ b/src/Random/HmacRandomNumberGenerator.php
@@ -108,6 +108,14 @@ class HmacRandomNumberGenerator implements RandomNumberGeneratorInterface
     }
 
     /**
+     * @return string
+     */
+    protected function optionalSuffix(): string
+    {
+        return '';
+    }
+
+    /**
      * @param \GMP $q
      * @return \GMP
      */
@@ -117,6 +125,7 @@ class HmacRandomNumberGenerator implements RandomNumberGeneratorInterface
         $rlen = $this->math->rightShift($this->math->add($qlen, gmp_init(7, 10)), 3);
         $hlen = $this->getHashLength($this->algorithm);
         $bx = $this->int2octets($this->privateKey->getSecret(), $rlen) . $this->int2octets($this->messageHash, $rlen);
+        $bx .= $this->optionalSuffix();
 
         $v = str_pad('', $hlen >> 3, "\x01", STR_PAD_LEFT);
         $k = str_pad('', $hlen >> 3, "\x00", STR_PAD_LEFT);

--- a/tests/unit/Random/HedgedRandomNumberGeneratorTest.php
+++ b/tests/unit/Random/HedgedRandomNumberGeneratorTest.php
@@ -5,10 +5,11 @@ namespace Mdanter\Ecc\Tests\Random;
 
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Crypto\Key\PrivateKey;
+use Mdanter\Ecc\Random\HedgedRandomNumberGenerator;
 use Mdanter\Ecc\Random\HmacRandomNumberGenerator;
 use Mdanter\Ecc\Tests\AbstractTestCase;
 
-class HmacRandomNumberGeneratorTest extends AbstractTestCase
+class HedgedRandomNumberGeneratorTest extends AbstractTestCase
 {
     public function testRequireValidAlgorithm()
     {
@@ -20,19 +21,20 @@ class HmacRandomNumberGeneratorTest extends AbstractTestCase
         $privateKey  = new PrivateKey($math, $g, gmp_init(1, 10));
         $hash = gmp_init(hash('sha256', 'message', false), 16);
 
-        new HmacRandomNumberGenerator($math, $privateKey, $hash, 'sha256aaaa');
+        new HedgedRandomNumberGenerator($math, $privateKey, $hash, 'sha256aaaa');
     }
 
     public function testOutputDynamic()
-    {
+    {;
+
         $math = EccFactory::getAdapter();
         $g = EccFactory::getNistCurves()->generator192();
         $privateKey  = new PrivateKey($math, $g, gmp_init(random_int(1, PHP_INT_MAX), 10));
 
         $hash = gmp_init(hash('sha256', 'message', false), 16);
-        $rng = new HmacRandomNumberGenerator($math, $privateKey, $hash, 'sha256');
+        $rng = new HedgedRandomNumberGenerator($math, $privateKey, $hash, 'sha256');
         $x = $rng->generate($g->getOrder());
         $y = $rng->generate($g->getOrder());
-        $this->assertSame(gmp_strval($x, 16), gmp_strval($y, 16));
+        $this->assertNotSame(gmp_strval($x, 16), gmp_strval($y, 16));
     }
 }


### PR DESCRIPTION
While deterministic signatures are a wonderful way to prevent biased RNGs from leaking your k value, they're susceptible to fault attacks.

https://eprint.iacr.org/2017/1014

If you can change the message hash being signed from M1 to M2 during k generation (but back to M1 during actual signing), and then obtain a valid signature for M1, you've leaked the k-value again!

To offset this, inject 32 bytes of randomness to signature k-value generation (but also use the HMAC determinism). This is the best of both worlds.

The IETF's CFRG calls these "Hedged Signatures".