### PR TITLE
Remove deprecated dynamic properties in NumberTheory for PHP >=8.2

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -34,7 +34,6 @@ filter:
 
 tools:
     php_cpd: true
-    php_pdepend: true
     php_analyzer: true
     php_sim: true
     php_changetracking: true

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Support for older PHP versions:
 
 You can install this library via Composer :
 
-`composer require shanecurran/ecc`
+`composer require shanecurran/phpecc`
 
 ### Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 ## Pure PHP Elliptic Curve DSA and DH
 
-[![Latest Stable Version](https://poser.pugx.org/mdanter/ecc/v/stable.png)](https://packagist.org/packages/mdanter/ecc)
-[![Total Downloads](https://poser.pugx.org/mdanter/ecc/downloads.png)](https://packagist.org/packages/mdanter/ecc)
-[![Latest Unstable Version](https://poser.pugx.org/mdanter/ecc/v/unstable.png)](https://packagist.org/packages/mdanter/ecc)
-[![License](https://poser.pugx.org/mdanter/ecc/license.png)](https://packagist.org/packages/mdanter/ecc)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/shanecurran/phpecc/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/shanecurran/phpecc?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/shanecurran/phpecc/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/shanecurran/phpecc/?branch=master)
+
+
+[![Latest Stable Version](https://poser.pugx.org/shanecurran/phpecc/v/stable.png)](https://packagist.org/packages/shanecurran/phpecc)
+[![Total Downloads](https://poser.pugx.org/shanecurran/phpecc/downloads.png)](https://packagist.org/packages/shanecurran/phpecc)
+[![Latest Unstable Version](https://poser.pugx.org/shanecurran/phpecc/v/unstable.png)](https://packagist.org/packages/shanecurran/phpecc)
+[![License](https://poser.pugx.org/shanecurran/phpecc/license.png)](https://packagist.org/packages/shanecurran/phpecc)
 
 ### Information
 
@@ -48,11 +52,16 @@ Support for older PHP versions:
 
 You can install this library via Composer :
 
-`composer require shanecurran/phpecc`
+`composer require shanecurran/ecc`
 
 ### Contribute
 
 When sending in pull requests, please make sure to run the `make` command.
+
+The default target runs all PHPUnit and PHPCS tests. All tests
+must validate for your contribution to be accepted.
+
+It's also always a good idea to check the results of the [Scrutinizer analysis](https://scrutinizer-ci.com/g/shanecurran/phpecc/) for your pull requests.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 ## Pure PHP Elliptic Curve DSA and DH
 
-[![Build Status](https://travis-ci.org/phpecc/phpecc.svg?branch=master)](https://travis-ci.org/phpecc/phpecc)
-
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/phpecc/phpecc/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/phpecc/phpecc?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/phpecc/phpecc/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/phpecc/phpecc/?branch=master)
-
 [![Latest Stable Version](https://poser.pugx.org/mdanter/ecc/v/stable.png)](https://packagist.org/packages/mdanter/ecc)
 [![Total Downloads](https://poser.pugx.org/mdanter/ecc/downloads.png)](https://packagist.org/packages/mdanter/ecc)
 [![Latest Unstable Version](https://poser.pugx.org/mdanter/ecc/v/unstable.png)](https://packagist.org/packages/mdanter/ecc)
@@ -12,7 +7,7 @@
 
 ### Information
 
-This library is a rewrite/update of Matyas Danter's ECC library. All credit goes to him.
+This library is an actively maintained fork of Thomas Kerin's [`phpecc`](https://github.com/phpecc/phpecc) library, which is a rewrite/update of Matyas Danter's ECC library. All credit goes to them.
 
 For more information on Elliptic Curve Cryptography please read [this fine article](http://www.matyasdanter.com/2010/12/elliptic-curve-php-oop-dsa-and-diffie-hellman/).
 
@@ -53,16 +48,11 @@ Support for older PHP versions:
 
 You can install this library via Composer :
 
-`composer require mdanter/ecc:^1.0`
+`composer require shanecurran/phpecc`
 
 ### Contribute
 
 When sending in pull requests, please make sure to run the `make` command.
-
-The default target runs all PHPUnit and PHPCS tests. All tests
-must validate for your contribution to be accepted.
-
-It's also always a good idea to check the results of the [Scrutinizer analysis](https://scrutinizer-ci.com/g/phpecc/phpecc/) for your pull requests.
 
 ### Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "mdanter/ecc",
+    "name": "shanecurran/phpecc",
     "description": "PHP Elliptic Curve Cryptography library",
     "type": "library",
-    "homepage": "https://github.com/phpecc/phpecc",
+    "homepage": "https://github.com/shanecurran/phpecc",
     "keywords": ["secp256k1", "secp256r1", "nistp192", "nistp224", "nistp256", "nistp384", "nistp521", "ECDSA", "diffie", "hellman", "ECDH", "elliptic", "curve", "phpecc"],
     "license": "MIT",
     "authors": [
@@ -20,6 +20,11 @@
         {
             "name": "Thomas Kerin",
             "email": "afk11@users.noreply.github.com",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Shane Curran",
+            "email": "shanecurran@users.noreply.github.com",
             "role": "Maintainer"
         }
     ],

--- a/src/Math/NumberTheory.php
+++ b/src/Math/NumberTheory.php
@@ -43,6 +43,22 @@ class NumberTheory
      * @var GmpMathInterface
      */
     private $adapter;
+    
+    /**
+     * @var GMP
+     */
+    private $zero;
+    
+    /**
+     * @var GMP
+     */
+    private $one;
+
+    /**
+     * @var GMP
+     */
+    private $two;
+
 
     /**
      * @param GmpMathInterface $adapter


### PR DESCRIPTION
As of PHP >=8.2, dynamic properties have been deprecated. 

This results in a large volume of log noise when performing any `NumberTheory` operations. This PR is the beginning of a project to remove deprecated dynamic properties.